### PR TITLE
fix invalid handling of mixed string/number in makeNumber

### DIFF
--- a/src/type-coerce/make-primitive.test.ts
+++ b/src/type-coerce/make-primitive.test.ts
@@ -19,6 +19,7 @@ it('makeNumber', () => {
   expect(makeNumber(true)).toBe(1);
   expect(makeNumber(false)).toBe(0);
   expect(() => makeNumber(null)).toThrow('Unable to cast object to Number');
+  expect(() => makeNumber('4four')).toThrow('Unable to cast string to Number');
   expect(() => makeNumber(undefined)).toThrow('Unable to cast undefined to Number');
   expect(() => makeNumber(() => true)).toThrow('Unable to cast function to Number');
   expect(() => makeNumber([])).toThrow('Unable to cast object to Number');

--- a/src/type-coerce/make-primitive.ts
+++ b/src/type-coerce/make-primitive.ts
@@ -16,7 +16,7 @@ export function makeNumber(obj: unknown): number {
     return obj;
   }
   if (isString(obj)) {
-    const value = parseFloat(obj);
+    const value = +obj; // unlike parseFloat this will return NaN for strings like '4four'
     if (!isNaN(value)) {
       return value;
     }


### PR DESCRIPTION
When coercing a string `makeNumber` used `parseFloat` under the hood, which makes a best attempt conversion for a string that starts as a number. Meaning values like `4all` would be parsed as `4` without emitting any errors. This change converts it to the unary plus operator, which produces `NaN` for that value instead. Values such as `4e1` and `0b10` are still allowed.