### PR TITLE
feature: inspectType

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ npm install ts-runtime-typecheck
   - [Reference: Optional Type Checks](#reference-optional-type-checks)
   - [Reference: Type Coerce](#reference-type-coerce)
   - [Reference: Type Assert](#reference-type-assert)
-  - [Reference: Types](#reference-types)
   - [Reference: Helper functions](#reference-helper-functions)
+  - [Reference: Types](#reference-types)
 
 - [Changelog](#changelog)
   - [v1.0.0](#v100)
@@ -902,7 +902,7 @@ Assert value of type `JSONValue | undefined` is `JSONObject | undefined`. Accept
 
 - ### inspectType
 
-Inspects the type of a given value and returns a description of it as a string. Useful for constructing debug messages from unknown values. Instances of classes are described using the name of their class. Abstract objects are traversed recursively so that their elements can also be described as well. Recursion uses a depth limit to prevent overlarge descriptions. Once the limit has been reached objects will be described as `Dictionary`.
+Inspects the type of a given value and returns a description of it as a string. Useful for constructing debug messages from unknown values. Instances of classes are described using the name of their class. Abstract objects are traversed recursively so that their elements can be described as well. Recursion uses a depth limit to prevent overlarge descriptions. Once the limit has been reached abstract objects will be described as `Dictionary`.
 
 An optional second argument can be passed to modify the default behaviour. For example you can change the `maxDepth` limit from it's default of `3`; a value of `0` would prevent recursion whereas `Infinity` would remove the limit.
 
@@ -1081,3 +1081,4 @@ inspectType({ foo: 'bar' }, { maxDepth: 0 }); // Dictionary
 
 - Add: `inspectType` function to describe the type of a value
 - Fix: `makeNumber` no longer returns a number strings prefixed with a number
+- Change: Type error messages now use the more descriptive `inspectType` instead of `typeof` for erroneous values

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ npm install ts-runtime-typecheck
   - [Reference: Type Coerce](#reference-type-coerce)
   - [Reference: Type Assert](#reference-type-assert)
   - [Reference: Types](#reference-types)
+  - [Reference: Helper functions](#reference-helper-functions)
+
 - [Changelog](#changelog)
   - [v1.0.0](#v100)
   - [v1.1.0](#v110)
@@ -52,6 +54,8 @@ npm install ts-runtime-typecheck
   - [v2.2.1](#221)
   - [v2.2.2](#222)
   - [v2.3.0](#230)
+  - [v2.4.0](#240)
+  - [v2.5.0](#250)
 
 ## Type Casts
 
@@ -896,6 +900,33 @@ Assert value of type `JSONValue | undefined` is `JSONObject | undefined`. Accept
   }
   ```
 
+- ### inspectType
+
+Inspects the type of a given value and returns a description of it as a string. Useful for constructing debug messages from unknown values. Instances of classes are described using the name of their class. Abstract objects are traversed recursively so that their elements can also be described as well. Recursion uses a depth limit to prevent overlarge descriptions. Once the limit has been reached objects will be described as `Dictionary`.
+
+An optional second argument can be passed to modify the default behaviour. For example you can change the `maxDepth` limit from it's default of `3`; a value of `0` would prevent recursion whereas `Infinity` would remove the limit.
+
+Arrays currently do not feature recursive type description, but this might be introduced in future.
+
+Internally this is used to describe values in type error messages.
+
+```typescript
+import { inspectType } from 'ts-runtime-typecheck';
+
+class Example {}
+
+inspectType('hello world'); // string
+inspectType(null) // null
+inspectType([]) // Array
+inspectType(new Example) // Example
+inspectType({}) // {}
+inspectType({
+  foo: 'hello',
+  bar: 'world'
+}) // { foo: string, bar: string }
+inspectType({ foo: 'bar' }, { maxDepth: 0 }); // Dictionary
+```
+
 ### Reference: Types
 
 - ### JSONValue
@@ -1045,3 +1076,8 @@ Assert value of type `JSONValue | undefined` is `JSONObject | undefined`. Accept
 - Add: Literal type casts and checks
 - Add: Primitive type, casts and checks
 - Documentation: Correct some typos in the `isStruct`/`asStruct` examples
+
+### 2.5.0
+
+- Add: `inspectType` function to describe the type of a value
+- Fix: `makeNumber` no longer returns a number strings prefixed with a number

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-runtime-typecheck",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-runtime-typecheck",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "description": "A collection of common types for TypeScript along with dynamic type cast methods.",
   "main": "cjs/index.js",
   "module": "mjs/index.mjs",

--- a/src/Definition.type.ts
+++ b/src/Definition.type.ts
@@ -1,0 +1,14 @@
+/**
+ * Definition embodies the definition of a type e.g.
+ * 
+ * ```
+ * let a: Definition = 'number';
+ * let b: Definition = {
+ *   foo: 'number',
+ *   bar: { isNext: 'boolean' }
+ * }
+ * ```
+ */
+export type Definition = string | {
+  [key: string]: Definition
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export * from './type-assert/assert-primitive';
 
 export { TypeAssertion } from './TypeAssertion';
 export { invariant } from './invariant';
+export { inspectType } from './inspectType';
 
 export type { Index, Indexable } from './Index.type';
 export type { Primitive } from './Primitive.type';

--- a/src/inspectType.test.ts
+++ b/src/inspectType.test.ts
@@ -1,0 +1,38 @@
+import { inspectType } from './inspectType';
+
+describe('inspectType', () => {
+  it('string', () => {
+    expect(inspectType('hello')).toBe('string');
+  });
+  it('number', () => {
+    expect(inspectType(12)).toBe('number');
+  });
+  it('boolean', () => {
+    expect(inspectType(false)).toBe('boolean');
+  });
+  it('Array', () => {
+    expect(inspectType([])).toBe('Array');
+  });
+  it('null', () => {
+    expect(inspectType(null)).toBe('null');
+  });
+  it('empty object', () => {
+    expect(inspectType({})).toBe('{}');
+  });
+  it('empty object with 0 depth', () => {
+    expect(inspectType({}, 0)).toBe('Dictionary');
+  });
+  it('object with single element', () => {
+    expect(inspectType({ hello: 'world' })).toBe('{ hello: string }');
+  });
+  it('object with multiple element', () => {
+    expect(inspectType({ hello: 'world', foo: 'bar' })).toBe('{ hello: string, foo: string }');
+  });
+  it('object with default max depth nesting', () => {
+    expect(inspectType({ hello: { bar: { foo: { secret: '' }}} })).toBe('{ hello: { bar: { foo: Dictionary } } }');
+  });
+  it('instance of class', () => {
+    class Alpha {}
+    expect(inspectType(new Alpha)).toBe('Alpha');
+  });
+});

--- a/src/inspectType.test.ts
+++ b/src/inspectType.test.ts
@@ -20,7 +20,7 @@ describe('inspectType', () => {
     expect(inspectType({})).toBe('{}');
   });
   it('empty object with 0 depth', () => {
-    expect(inspectType({}, 0)).toBe('Dictionary');
+    expect(inspectType({}, { maxDepth: 0 })).toBe('Dictionary');
   });
   it('object with single element', () => {
     expect(inspectType({ hello: 'world' })).toBe('{ hello: string }');

--- a/src/inspectType.ts
+++ b/src/inspectType.ts
@@ -1,7 +1,13 @@
 import type { Dictionary } from './Dictionary.type';
 import { stringifyDefinition } from './stringifyDefinition';
 
-export function inspectType (value: unknown, maxDepth = 3): string {
+export interface InspectTypeOptions {
+  maxDepth?: number;
+}
+
+export function inspectType (value: unknown, opts: InspectTypeOptions = {}): string {
+  const { maxDepth = 3 } = opts;
+
   if (typeof value !== 'object') {
     return typeof value;
   }
@@ -27,9 +33,11 @@ export function inspectType (value: unknown, maxDepth = 3): string {
 
   // We construct a definition by recursively calling inspectType on the elements of the Dictionary
   const result: Dictionary<string> = {};
-  
+  // reduce the depth limit by 1 when we recurse
+  const nestedOptions = { ...opts, maxDepth: maxDepth - 1 };
+
   for (const [k, v] of Object.entries(value)) {
-    result[k] = inspectType(v, maxDepth - 1);
+    result[k] = inspectType(v, nestedOptions);
   }
 
   // Then serialise the definition

--- a/src/inspectType.ts
+++ b/src/inspectType.ts
@@ -1,0 +1,37 @@
+import type { Dictionary } from './Dictionary.type';
+import { stringifyDefinition } from './stringifyDefinition';
+
+export function inspectType (value: unknown, maxDepth = 3): string {
+  if (typeof value !== 'object') {
+    return typeof value;
+  }
+  
+  if (value === null) {
+    return 'null';
+  }
+  
+  if (Array.isArray(value)) {
+    // TODO give some indication of the interior type and length
+    // this is harder than it seems because the interior
+    // could be complex types, or a union of multiple types
+    return 'Array';
+  }
+  
+  if (value.constructor.name !== 'Object') {
+    return value.constructor.name;
+  }
+  
+  if (maxDepth <= 0) {
+    return 'Dictionary';
+  }
+
+  // We construct a definition by recursively calling inspectType on the elements of the Dictionary
+  const result: Dictionary<string> = {};
+  
+  for (const [k, v] of Object.entries(value)) {
+    result[k] = inspectType(v, maxDepth - 1);
+  }
+
+  // Then serialise the definition
+  return stringifyDefinition(result);
+}

--- a/src/stringifyDefinition.ts
+++ b/src/stringifyDefinition.ts
@@ -1,0 +1,13 @@
+import type { Definition } from './Definition.type';
+
+export function stringifyDefinition (value: Definition): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  const elements = Object.entries(value);
+  if (elements.length === 0) {
+    return '{}';
+  }
+  return `{ ${elements.map(([k, v]) => `${k}: ${stringifyDefinition(v)}`).join(', ')} }`;
+}

--- a/src/type-cast/as-instance.test.ts
+++ b/src/type-cast/as-instance.test.ts
@@ -2,13 +2,13 @@ import { asInstance, asOptInstance } from './as-instance';
 
 describe('as instance', () => {
   class BaseClass {
-    inner = 0
+    inner = 0;
   }
   class ExtendedClass extends BaseClass {
-    outer = 'a word'
+    outer = 'a word';
   }
   class Similar {
-    inner = 1
+    inner = 1;
   }
 
   const base = new BaseClass;
@@ -22,16 +22,16 @@ describe('as instance', () => {
     expect(asInstance(BaseClass)(extended)).toBe(extended);
   });
   it('does not match a similar class', () => {
-    expect(() => asInstance(BaseClass)(similar)).toThrowError('Unable to cast object to BaseClass');
+    expect(() => asInstance(BaseClass)(similar)).toThrowError('Unable to cast Similar to BaseClass');
   });
   it('a check for an extended class does not match the base', () => {
-    expect(() => asInstance(ExtendedClass)(base)).toThrowError('Unable to cast object to ExtendedClass');
+    expect(() => asInstance(ExtendedClass)(base)).toThrowError('Unable to cast BaseClass to ExtendedClass');
   });
   it('does not match undefined', () => {
     expect(() => asInstance(BaseClass)(undefined)).toThrowError('Unable to cast undefined to BaseClass');
   });
   it('does not match null', () => {
-    expect(() => asInstance(BaseClass)(null)).toThrowError('Unable to cast object to BaseClass');
+    expect(() => asInstance(BaseClass)(null)).toThrowError('Unable to cast null to BaseClass');
   });
   it('returns a fallback parameter', () => {
     expect(asInstance(BaseClass)(null, base)).toBe(base);
@@ -41,13 +41,13 @@ describe('as instance', () => {
 
 describe('is optional instance', () => {
   class BaseClass {
-    inner = 0
+    inner = 0;
   }
   class ExtendedClass extends BaseClass {
-    outer = 'a word'
+    outer = 'a word';
   }
   class Similar {
-    inner = 1
+    inner = 1;
   }
 
   const base = new BaseClass;
@@ -61,10 +61,10 @@ describe('is optional instance', () => {
     expect(asOptInstance(BaseClass)(extended)).toBe(extended);
   });
   it('does not match a similar class', () => {
-    expect(() => asOptInstance(BaseClass)(similar)).toThrowError('Unable to cast object to Optional<BaseClass>');
+    expect(() => asOptInstance(BaseClass)(similar)).toThrowError('Unable to cast Similar to Optional<BaseClass>');
   });
   it('a check for an extended class does not match the base', () => {
-    expect(() => asOptInstance(ExtendedClass)(base)).toThrowError('Unable to cast object to Optional<ExtendedClass>');
+    expect(() => asOptInstance(ExtendedClass)(base)).toThrowError('Unable to cast BaseClass to Optional<ExtendedClass>');
   });
   it('matches undefined', () => {
     expect(asOptInstance(BaseClass)(undefined)).toBe(undefined);

--- a/src/type-cast/as-json.test.ts
+++ b/src/type-cast/as-json.test.ts
@@ -35,10 +35,10 @@ describe('asJSONValue', () => {
     expect(() => asJSONValue(undefined)).toThrow('Unable to cast undefined to JSONValue');
   });
   it('does not accept array elements that aren\'t JSONValue', () => {
-    expect(() => asJSONValue([ Symbol('bad') ])).toThrow('Unable to cast object to JSONValue');
+    expect(() => asJSONValue([ Symbol('bad') ])).toThrow('Unable to cast Array to JSONValue');
   });
   it('does not accept object values that aren\'t JSONValue', () => {
-    expect(() => asJSONValue({ val: Symbol('bad') })).toThrow('Unable to cast object to JSONValue');
+    expect(() => asJSONValue({ val: Symbol('bad') })).toThrow('Unable to cast { val: symbol } to JSONValue');
   });
 });
 
@@ -47,10 +47,10 @@ describe('asJSONArray', () => {
     expect(asJSONArray([ 12 ])).toEqual([ 12 ]);
   });
   it('doesn\'t accept object', () => {
-    expect(() => asJSONArray({ val: 12 })).toThrow('Unable to cast object to JSONArray');
+    expect(() => asJSONArray({ val: 12 })).toThrow('Unable to cast { val: number } to JSONArray');
   });
   it('doesn\'t accept null', () => {
-    expect(() => asJSONArray(null)).toThrow('Unable to cast object to JSONArray');
+    expect(() => asJSONArray(null)).toThrow('Unable to cast null to JSONArray');
   });
   it('doesn\'t accept primitives', () => {
     expect(() => asJSONArray(12)).toThrow('Unable to cast number to JSONArray');
@@ -64,10 +64,10 @@ describe('asJSONObject', () => {
     expect(asJSONObject({ val: 12, 42: 'Life' })).toEqual({ val: 12, 42: 'Life' });
   });
   it('doesn\'t accept array', () => {
-    expect(() => asJSONObject([ 12 ])).toThrow('Unable to cast object to JSONObject');
+    expect(() => asJSONObject([ 12 ])).toThrow('Unable to cast Array to JSONObject');
   });
   it('doesn\'t accept null', () => {
-    expect(() => asJSONObject(null)).toThrow('Unable to cast object to JSONObject');
+    expect(() => asJSONObject(null)).toThrow('Unable to cast null to JSONObject');
   });
   it('doesn\'t accept primitives', () => {
     expect(() => asJSONObject(12)).toThrow('Unable to cast number to JSONObject');
@@ -114,10 +114,10 @@ describe('asOptJSONValue', () => {
     expect(asOptJSONValue(undefined)).toBe(undefined);
   });
   it('does not accept array elements that aren\'t JSONValue', () => {
-    expect(() => asOptJSONValue([ Symbol('bad') ])).toThrow('Unable to cast object to Optional<JSONValue>');
+    expect(() => asOptJSONValue([ Symbol('bad') ])).toThrow('Unable to cast Array to Optional<JSONValue>');
   });
   it('does not accept object values that aren\'t JSONValue', () => {
-    expect(() => asOptJSONValue({ val: Symbol('bad') })).toThrow('Unable to cast object to Optional<JSONValue>');
+    expect(() => asOptJSONValue({ val: Symbol('bad') })).toThrow('Unable to cast { val: symbol } to Optional<JSONValue>');
   });
 });
 
@@ -126,7 +126,7 @@ describe('asOptJSONArray', () => {
     expect(asOptJSONArray([ 12 ])).toEqual([ 12 ]);
   });
   it('doesn\'t accept object', () => {
-    expect(() => asOptJSONArray({ val: 12 })).toThrow('Unable to cast object to Optional<JSONArray>');
+    expect(() => asOptJSONArray({ val: 12 })).toThrow('Unable to cast { val: number } to Optional<JSONArray>');
   });
   it('accepts nullish', () => {
     expect(asOptJSONArray(null)).toBe(undefined);
@@ -144,7 +144,7 @@ describe('asOptJSONObject', () => {
     expect(asOptJSONObject({ val: 12, 42: 'Life' })).toEqual({ val: 12, 42: 'Life' });
   });
   it('doesn\'t accept array', () => {
-    expect(() => asOptJSONObject([ 12 ])).toThrow('Unable to cast object to Optional<JSONObject>');
+    expect(() => asOptJSONObject([ 12 ])).toThrow('Unable to cast Array to Optional<JSONObject>');
   });
   it('accepts nullish', () => {
     expect(asOptJSONObject(null)).toBe(undefined);

--- a/src/type-cast/as-primitive.test.ts
+++ b/src/type-cast/as-primitive.test.ts
@@ -12,10 +12,10 @@ describe('primative casts', () => {
     // should fail
     expect(() => asString(0)).toThrow('Unable to cast number to string');
     expect(() => asString(false)).toThrow('Unable to cast boolean to string');
-    expect(() => asString(null)).toThrow('Unable to cast object to string');
+    expect(() => asString(null)).toThrow('Unable to cast null to string');
     expect(() => asString(undefined)).toThrow('Unable to cast undefined to string');
-    expect(() => asString([])).toThrow('Unable to cast object to string');
-    expect(() => asString({})).toThrow('Unable to cast object to string');
+    expect(() => asString([])).toThrow('Unable to cast Array to string');
+    expect(() => asString({})).toThrow('Unable to cast {} to string');
     expect(() => asString(fn)).toThrow('Unable to cast function to string');
   });
   it('asNumber', () => {
@@ -27,10 +27,10 @@ describe('primative casts', () => {
     // should fail
     expect(() => asNumber('hi')).toThrow('Unable to cast string to number');
     expect(() => asNumber(false)).toThrow('Unable to cast boolean to number');
-    expect(() => asNumber(null)).toThrow('Unable to cast object to number');
+    expect(() => asNumber(null)).toThrow('Unable to cast null to number');
     expect(() => asNumber(undefined)).toThrow('Unable to cast undefined to number');
-    expect(() => asNumber([])).toThrow('Unable to cast object to number');
-    expect(() => asNumber({})).toThrow('Unable to cast object to number');
+    expect(() => asNumber([])).toThrow('Unable to cast Array to number');
+    expect(() => asNumber({})).toThrow('Unable to cast {} to number');
     expect(() => asNumber(fn)).toThrow('Unable to cast function to number');
 
   });
@@ -47,7 +47,7 @@ describe('primative casts', () => {
     expect(asDefined(undefined, 12)).toBe(12);
     // should fail
     expect(() => asDefined(undefined)).toThrow('Unable to cast undefined to NonNullable<unknown>');
-    expect(() => asDefined(null)).toThrow('Unable to cast object to NonNullable<unknown>');
+    expect(() => asDefined(null)).toThrow('Unable to cast null to NonNullable<unknown>');
   });
   it('asIndex', () => {
     // intended
@@ -60,10 +60,10 @@ describe('primative casts', () => {
     expect(asIndex(undefined, 'a')).toBe('a');
     // should fail
     expect(() => asIndex(false)).toThrow('Unable to cast boolean to Index');
-    expect(() => asIndex(null)).toThrow('Unable to cast object to Index');
+    expect(() => asIndex(null)).toThrow('Unable to cast null to Index');
     expect(() => asIndex(undefined)).toThrow('Unable to cast undefined to Index');
-    expect(() => asIndex([])).toThrow('Unable to cast object to Index');
-    expect(() => asIndex({})).toThrow('Unable to cast object to Index');
+    expect(() => asIndex([])).toThrow('Unable to cast Array to Index');
+    expect(() => asIndex({})).toThrow('Unable to cast {} to Index');
     expect(() => asIndex(fn)).toThrow('Unable to cast function to Index');
   });
   it('asIndexable', () => {
@@ -77,7 +77,7 @@ describe('primative casts', () => {
     expect(() => asIndexable(12)).toThrow('Unable to cast number to Indexable');
     expect(() => asIndexable('hi')).toThrow('Unable to cast string to Indexable');
     expect(() => asIndexable(false)).toThrow('Unable to cast boolean to Indexable');
-    expect(() => asIndexable(null)).toThrow('Unable to cast object to Indexable');
+    expect(() => asIndexable(null)).toThrow('Unable to cast null to Indexable');
     expect(() => asIndexable(undefined)).toThrow('Unable to cast undefined to Indexable');
     expect(() => asIndexable(fn)).toThrow('Unable to cast function to Indexable');
   });
@@ -94,10 +94,10 @@ describe('primative casts', () => {
     expect(asPrimitive(null, false)).toBe(false);
     expect(asPrimitive(undefined, true)).toBe(true);
     // should fail
-    expect(() => asPrimitive(null)).toThrow('Unable to cast object to Primitive');
+    expect(() => asPrimitive(null)).toThrow('Unable to cast null to Primitive');
     expect(() => asPrimitive(undefined)).toThrow('Unable to cast undefined to Primitive');
-    expect(() => asPrimitive([])).toThrow('Unable to cast object to Primitive');
-    expect(() => asPrimitive({})).toThrow('Unable to cast object to Primitive');
+    expect(() => asPrimitive([])).toThrow('Unable to cast Array to Primitive');
+    expect(() => asPrimitive({})).toThrow('Unable to cast {} to Primitive');
     expect(() => asPrimitive(fn)).toThrow('Unable to cast function to Primitive');
   });
   it('asBoolean', () => {
@@ -109,10 +109,10 @@ describe('primative casts', () => {
     // should fail
     expect(() => asBoolean(12)).toThrow('Unable to cast number to boolean');
     expect(() => asBoolean('hi')).toThrow('Unable to cast string to boolean');
-    expect(() => asBoolean(null)).toThrow('Unable to cast object to boolean');
+    expect(() => asBoolean(null)).toThrow('Unable to cast null to boolean');
     expect(() => asBoolean(undefined)).toThrow('Unable to cast undefined to boolean');
-    expect(() => asBoolean([])).toThrow('Unable to cast object to boolean');
-    expect(() => asBoolean({})).toThrow('Unable to cast object to boolean');
+    expect(() => asBoolean([])).toThrow('Unable to cast Array to boolean');
+    expect(() => asBoolean({})).toThrow('Unable to cast {} to boolean');
     expect(() => asBoolean(fn)).toThrow('Unable to cast function to boolean');
   });
   it('asArray', () => {
@@ -125,9 +125,9 @@ describe('primative casts', () => {
     expect(() => asArray(12)).toThrow('Unable to cast number to unknown[]');
     expect(() => asArray('hi')).toThrow('Unable to cast string to unknown[]');
     expect(() => asArray(false)).toThrow('Unable to cast boolean to unknown[]');
-    expect(() => asArray(null)).toThrow('Unable to cast object to unknown[]');
+    expect(() => asArray(null)).toThrow('Unable to cast null to unknown[]');
     expect(() => asArray(undefined)).toThrow('Unable to cast undefined to unknown[]');
-    expect(() => asArray({})).toThrow('Unable to cast object to unknown[]');
+    expect(() => asArray({})).toThrow('Unable to cast {} to unknown[]');
     expect(() => asArray(fn)).toThrow('Unable to cast function to unknown[]');
   });
   it('asDictionary', () => {
@@ -140,9 +140,9 @@ describe('primative casts', () => {
     expect(() => asDictionary(12)).toThrow('Unable to cast number to Dictionary');
     expect(() => asDictionary('hi')).toThrow('Unable to cast string to Dictionary');
     expect(() => asDictionary(false)).toThrow('Unable to cast boolean to Dictionary');
-    expect(() => asDictionary(null)).toThrow('Unable to cast object to Dictionary');
+    expect(() => asDictionary(null)).toThrow('Unable to cast null to Dictionary');
     expect(() => asDictionary(undefined)).toThrow('Unable to cast undefined to Dictionary');
-    expect(() => asDictionary([])).toThrow('Unable to cast object to Dictionary');
+    expect(() => asDictionary([])).toThrow('Unable to cast Array to Dictionary');
     expect(() => asDictionary(fn)).toThrow('Unable to cast function to Dictionary');
   });
   it('asFunction', () => {
@@ -155,10 +155,10 @@ describe('primative casts', () => {
     expect(() => asFunction(12)).toThrow('Unable to cast number to UnknownFunction');
     expect(() => asFunction('hi')).toThrow('Unable to cast string to UnknownFunction');
     expect(() => asFunction(false)).toThrow('Unable to cast boolean to UnknownFunction');
-    expect(() => asFunction(null)).toThrow('Unable to cast object to UnknownFunction');
+    expect(() => asFunction(null)).toThrow('Unable to cast null to UnknownFunction');
     expect(() => asFunction(undefined)).toThrow('Unable to cast undefined to UnknownFunction');
-    expect(() => asFunction([])).toThrow('Unable to cast object to UnknownFunction');
-    expect(() => asFunction({})).toThrow('Unable to cast object to UnknownFunction');
+    expect(() => asFunction([])).toThrow('Unable to cast Array to UnknownFunction');
+    expect(() => asFunction({})).toThrow('Unable to cast {} to UnknownFunction');
   });
 
   it('asOptString', () => {
@@ -169,8 +169,8 @@ describe('primative casts', () => {
     // should fail
     expect(() => asOptString(0)).toThrow('Unable to cast number to Optional<string>');
     expect(() => asOptString(false)).toThrow('Unable to cast boolean to Optional<string>');
-    expect(() => asOptString([])).toThrow('Unable to cast object to Optional<string>');
-    expect(() => asOptString({})).toThrow('Unable to cast object to Optional<string>');
+    expect(() => asOptString([])).toThrow('Unable to cast Array to Optional<string>');
+    expect(() => asOptString({})).toThrow('Unable to cast {} to Optional<string>');
     expect(() => asOptString(fn)).toThrow('Unable to cast function to Optional<string>');
   });
   it('asOptNumber', () => {
@@ -181,8 +181,8 @@ describe('primative casts', () => {
     // should fail
     expect(() => asOptNumber('hi')).toThrow('Unable to cast string to Optional<number>');
     expect(() => asOptNumber(false)).toThrow('Unable to cast boolean to Optional<number>');
-    expect(() => asOptNumber([])).toThrow('Unable to cast object to Optional<number>');
-    expect(() => asOptNumber({})).toThrow('Unable to cast object to Optional<number>');
+    expect(() => asOptNumber([])).toThrow('Unable to cast Array to Optional<number>');
+    expect(() => asOptNumber({})).toThrow('Unable to cast {} to Optional<number>');
     expect(() => asOptNumber(fn)).toThrow('Unable to cast function to Optional<number>');
 
   });
@@ -194,8 +194,8 @@ describe('primative casts', () => {
     expect(asOptIndex(undefined)).toBeUndefined();
     // should fail
     expect(() => asOptIndex(false)).toThrow('Unable to cast boolean to Optional<Index>');
-    expect(() => asOptIndex([])).toThrow('Unable to cast object to Optional<Index>');
-    expect(() => asOptIndex({})).toThrow('Unable to cast object to Optional<Index>');
+    expect(() => asOptIndex([])).toThrow('Unable to cast Array to Optional<Index>');
+    expect(() => asOptIndex({})).toThrow('Unable to cast {} to Optional<Index>');
     expect(() => asOptIndex(fn)).toThrow('Unable to cast function to Optional<Index>');
   });
   it('asOptPrimitive', () => {
@@ -206,8 +206,8 @@ describe('primative casts', () => {
     expect(asOptPrimitive(null)).toBeUndefined();
     expect(asOptPrimitive(undefined)).toBeUndefined();
     // should fail
-    expect(() => asOptPrimitive([])).toThrow('Unable to cast object to Optional<Primitive>');
-    expect(() => asOptPrimitive({})).toThrow('Unable to cast object to Optional<Primitive>');
+    expect(() => asOptPrimitive([])).toThrow('Unable to cast Array to Optional<Primitive>');
+    expect(() => asOptPrimitive({})).toThrow('Unable to cast {} to Optional<Primitive>');
     expect(() => asOptPrimitive(fn)).toThrow('Unable to cast function to Optional<Primitive>');
   });
   it('asOptIndexable', () => {
@@ -230,8 +230,8 @@ describe('primative casts', () => {
     // should fail
     expect(() => asOptBoolean(12)).toThrow('Unable to cast number to Optional<boolean>');
     expect(() => asOptBoolean('hi')).toThrow('Unable to cast string to Optional<boolean>');
-    expect(() => asOptBoolean([])).toThrow('Unable to cast object to Optional<boolean>');
-    expect(() => asOptBoolean({})).toThrow('Unable to cast object to Optional<boolean>');
+    expect(() => asOptBoolean([])).toThrow('Unable to cast Array to Optional<boolean>');
+    expect(() => asOptBoolean({})).toThrow('Unable to cast {} to Optional<boolean>');
     expect(() => asOptBoolean(fn)).toThrow('Unable to cast function to Optional<boolean>');
   });
   it('asOptArray', () => {
@@ -243,7 +243,7 @@ describe('primative casts', () => {
     expect(() => asOptArray(12)).toThrow('Unable to cast number to Optional<unknown[]>');
     expect(() => asOptArray('hi')).toThrow('Unable to cast string to Optional<unknown[]>');
     expect(() => asOptArray(false)).toThrow('Unable to cast boolean to Optional<unknown[]>');
-    expect(() => asOptArray({})).toThrow('Unable to cast object to Optional<unknown[]>');
+    expect(() => asOptArray({})).toThrow('Unable to cast {} to Optional<unknown[]>');
     expect(() => asOptArray(fn)).toThrow('Unable to cast function to Optional<unknown[]>');
   });
   it('asOptDictionary', () => {
@@ -255,7 +255,7 @@ describe('primative casts', () => {
     expect(() => asOptDictionary(12)).toThrow('Unable to cast number to Optional<Dictionary>');
     expect(() => asOptDictionary('hi')).toThrow('Unable to cast string to Optional<Dictionary>');
     expect(() => asOptDictionary(false)).toThrow('Unable to cast boolean to Optional<Dictionary>');
-    expect(() => asOptDictionary([])).toThrow('Unable to cast object to Optional<Dictionary>');
+    expect(() => asOptDictionary([])).toThrow('Unable to cast Array to Optional<Dictionary>');
     expect(() => asOptDictionary(fn)).toThrow('Unable to cast function to Optional<Dictionary>');
   });
   it('asOptFunction', () => {
@@ -267,7 +267,7 @@ describe('primative casts', () => {
     expect(() => asOptFunction(12)).toThrow('Unable to cast number to Optional<UnknownFunction>');
     expect(() => asOptFunction('hi')).toThrow('Unable to cast string to Optional<UnknownFunction>');
     expect(() => asOptFunction(false)).toThrow('Unable to cast boolean to Optional<UnknownFunction>');
-    expect(() => asOptFunction([])).toThrow('Unable to cast object to Optional<UnknownFunction>');
-    expect(() => asOptFunction({})).toThrow('Unable to cast object to Optional<UnknownFunction>');
+    expect(() => asOptFunction([])).toThrow('Unable to cast Array to Optional<UnknownFunction>');
+    expect(() => asOptFunction({})).toThrow('Unable to cast {} to Optional<UnknownFunction>');
   });
 });

--- a/src/type-cast/as-primitive.ts
+++ b/src/type-cast/as-primitive.ts
@@ -1,3 +1,4 @@
+import { inspectType } from '../inspectType';
 import type { Optional } from '../Optional.type';
 
 import { isString, isNumber, isDefined, isArray, isBoolean, isFunction, isIndex, isDictionary, isIndexable, isPrimitive } from '../type-check/is-primitive';
@@ -23,7 +24,7 @@ export function asDefined<T> (obj: Optional<T>, fallback?: NonNullable<T>): NonN
   if (typeof fallback !== 'undefined') {
     return fallback;
   }
-  throw new Error(`Unable to cast ${typeof obj} to NonNullable<unknown>`);
+  throw new Error(`Unable to cast ${inspectType(obj)} to NonNullable<unknown>`);
 }
 
 export const asOptString = optTypeCast(isString);

--- a/src/type-cast/as-recursive.test.ts
+++ b/src/type-cast/as-recursive.test.ts
@@ -16,13 +16,13 @@ describe('recursive casts', () => {
     expect(asStringArray(null, [])).toEqual([]);
     expect(asStringArray(undefined, [])).toEqual([]);
     // should fail
-    expect(() => asStringArray([null, 'test'])).toThrow('Unable to cast object to string[]');
+    expect(() => asStringArray([null, 'test'])).toThrow('Unable to cast Array to string[]');
     expect(() => asStringArray(12)).toThrow('Unable to cast number to string[]');
     expect(() => asStringArray('hi')).toThrow('Unable to cast string to string[]');
     expect(() => asStringArray(false)).toThrow('Unable to cast boolean to string[]');
-    expect(() => asStringArray(null)).toThrow('Unable to cast object to string[]');
+    expect(() => asStringArray(null)).toThrow('Unable to cast null to string[]');
     expect(() => asStringArray(undefined)).toThrow('Unable to cast undefined to string[]');
-    expect(() => asStringArray({})).toThrow('Unable to cast object to string[]');
+    expect(() => asStringArray({})).toThrow('Unable to cast {} to string[]');
     expect(() => asStringArray(fn)).toThrow('Unable to cast function to string[]');
   });
 
@@ -44,13 +44,13 @@ describe('recursive casts', () => {
     expect(asStringRecord(null, {})).toEqual({});
     expect(asStringRecord(undefined, {})).toEqual({});
     // should fail
-    expect(() => asStringRecord({ a: 'test', b: null })).toThrow('Unable to cast object to Dictionary<string>');
+    expect(() => asStringRecord({ a: 'test', b: null })).toThrow('Unable to cast { a: string, b: null } to Dictionary<string>');
     expect(() => asStringRecord(12)).toThrow('Unable to cast number to Dictionary<string>');
     expect(() => asStringRecord('hi')).toThrow('Unable to cast string to Dictionary<string>');
     expect(() => asStringRecord(false)).toThrow('Unable to cast boolean to Dictionary<string>');
-    expect(() => asStringRecord(null)).toThrow('Unable to cast object to Dictionary<string>');
+    expect(() => asStringRecord(null)).toThrow('Unable to cast null to Dictionary<string>');
     expect(() => asStringRecord(undefined)).toThrow('Unable to cast undefined to Dictionary<string>');
-    expect(() => asStringRecord([])).toThrow('Unable to cast object to Dictionary<string>');
+    expect(() => asStringRecord([])).toThrow('Unable to cast Array to Dictionary<string>');
     expect(() => asStringRecord(fn)).toThrow('Unable to cast function to Dictionary<string>');
   });
 
@@ -76,11 +76,11 @@ describe('optional recursive casts', () => {
     expect(asOptStringArray(null)).toEqual(undefined);
     expect(asOptStringArray(undefined)).toEqual(undefined);
     // should fail
-    expect(() => asOptStringArray([null, 'test'])).toThrow('Unable to cast object to Optional<string[]>');
+    expect(() => asOptStringArray([null, 'test'])).toThrow('Unable to cast Array to Optional<string[]>');
     expect(() => asOptStringArray(12)).toThrow('Unable to cast number to Optional<string[]>');
     expect(() => asOptStringArray('hi')).toThrow('Unable to cast string to Optional<string[]>');
     expect(() => asOptStringArray(false)).toThrow('Unable to cast boolean to Optional<string[]>');
-    expect(() => asOptStringArray({})).toThrow('Unable to cast object to Optional<string[]>');
+    expect(() => asOptStringArray({})).toThrow('Unable to cast {} to Optional<string[]>');
     expect(() => asOptStringArray(fn)).toThrow('Unable to cast function to Optional<string[]>');
   });
 
@@ -101,11 +101,11 @@ describe('optional recursive casts', () => {
     expect(asOptStringRecord(null)).toEqual(undefined);
     expect(asOptStringRecord(undefined)).toEqual(undefined);
     // should fail
-    expect(() => asOptStringRecord({ a: 'test', b: null })).toThrow('Unable to cast object to Optional<Dictionary<string>>');
+    expect(() => asOptStringRecord({ a: 'test', b: null })).toThrow('Unable to cast { a: string, b: null } to Optional<Dictionary<string>>');
     expect(() => asOptStringRecord(12)).toThrow('Unable to cast number to Optional<Dictionary<string>>');
     expect(() => asOptStringRecord('hi')).toThrow('Unable to cast string to Optional<Dictionary<string>>');
     expect(() => asOptStringRecord(false)).toThrow('Unable to cast boolean to Optional<Dictionary<string>>');
-    expect(() => asOptStringRecord([])).toThrow('Unable to cast object to Optional<Dictionary<string>>');
+    expect(() => asOptStringRecord([])).toThrow('Unable to cast Array to Optional<Dictionary<string>>');
     expect(() => asOptStringRecord(fn)).toThrow('Unable to cast function to Optional<Dictionary<string>>');
   });
 

--- a/src/type-cast/as-struct.test.ts
+++ b/src/type-cast/as-struct.test.ts
@@ -17,9 +17,9 @@ describe('asStruct', () => {
     expect(() => asEmptyStruct('test')).toThrow(`Unable to cast string to ${label}`);
     expect(() => asEmptyStruct(0)).toThrow(`Unable to cast number to ${label}`);
     expect(() => asEmptyStruct(false)).toThrow(`Unable to cast boolean to ${label}`);
-    expect(() => asEmptyStruct(null)).toThrow(`Unable to cast object to ${label}`);
+    expect(() => asEmptyStruct(null)).toThrow(`Unable to cast null to ${label}`);
     expect(() => asEmptyStruct(undefined)).toThrow(`Unable to cast undefined to ${label}`);
-    expect(() => asEmptyStruct([])).toThrow(`Unable to cast object to ${label}`);
+    expect(() => asEmptyStruct([])).toThrow(`Unable to cast Array to ${label}`);
     expect(() => asEmptyStruct(fn)).toThrow(`Unable to cast function to ${label}`);
   });
 
@@ -32,14 +32,14 @@ describe('asStruct', () => {
     expect(asSimpleStruct(null, { value: 'hello' })).toEqual({ value: 'hello' });
     expect(asSimpleStruct(undefined, { value: 'hello' })).toEqual({ value: 'hello' });
     // should fail
-    expect(() => asSimpleStruct({ value: 12 })).toThrow(`Unable to cast object to ${label}`);
-    expect(() => asSimpleStruct({})).toThrow(`Unable to cast object to ${label}`);
+    expect(() => asSimpleStruct({ value: 12 })).toThrow(`Unable to cast { value: number } to ${label}`);
+    expect(() => asSimpleStruct({})).toThrow(`Unable to cast {} to ${label}`);
     expect(() => asSimpleStruct('test')).toThrow(`Unable to cast string to ${label}`);
     expect(() => asSimpleStruct(0)).toThrow(`Unable to cast number to ${label}`);
     expect(() => asSimpleStruct(false)).toThrow(`Unable to cast boolean to ${label}`);
-    expect(() => asSimpleStruct(null)).toThrow(`Unable to cast object to ${label}`);
+    expect(() => asSimpleStruct(null)).toThrow(`Unable to cast null to ${label}`);
     expect(() => asSimpleStruct(undefined)).toThrow(`Unable to cast undefined to ${label}`);
-    expect(() => asSimpleStruct([])).toThrow(`Unable to cast object to ${label}`);
+    expect(() => asSimpleStruct([])).toThrow(`Unable to cast Array to ${label}`);
     expect(() => asSimpleStruct(fn)).toThrow(`Unable to cast function to ${label}`);
   });
 
@@ -53,15 +53,15 @@ describe('asStruct', () => {
     expect(asNestedStruct(null, { value: { value: 'hello' } })).toEqual({ value: { value: 'hello' } });
     expect(asNestedStruct(undefined, { value: { value: 'hello' } })).toEqual({ value: { value: 'hello' } });
     // should fail
-    expect(() => asNestedStruct({ value: {}})).toThrow(`Unable to cast object to ${label}`);
-    expect(() => asNestedStruct({ value: 12 })).toThrow(`Unable to cast object to ${label}`);
-    expect(() => asNestedStruct({})).toThrow(`Unable to cast object to ${label}`);
+    expect(() => asNestedStruct({ value: {}})).toThrow(`Unable to cast { value: {} } to ${label}`);
+    expect(() => asNestedStruct({ value: 12 })).toThrow(`Unable to cast { value: number } to ${label}`);
+    expect(() => asNestedStruct({})).toThrow(`Unable to cast {} to ${label}`);
     expect(() => asNestedStruct('test')).toThrow(`Unable to cast string to ${label}`);
     expect(() => asNestedStruct(0)).toThrow(`Unable to cast number to ${label}`);
     expect(() => asNestedStruct(false)).toThrow(`Unable to cast boolean to ${label}`);
-    expect(() => asNestedStruct(null)).toThrow(`Unable to cast object to ${label}`);
+    expect(() => asNestedStruct(null)).toThrow(`Unable to cast null to ${label}`);
     expect(() => asNestedStruct(undefined)).toThrow(`Unable to cast undefined to ${label}`);
-    expect(() => asNestedStruct([])).toThrow(`Unable to cast object to ${label}`);
+    expect(() => asNestedStruct([])).toThrow(`Unable to cast Array to ${label}`);
     expect(() => asNestedStruct(fn)).toThrow(`Unable to cast function to ${label}`);
   });
 });
@@ -78,7 +78,7 @@ describe('asOptStruct', () => {
     expect(() => asEmptyStruct('test')).toThrow(`Unable to cast string to ${label}`);
     expect(() => asEmptyStruct(0)).toThrow(`Unable to cast number to ${label}`);
     expect(() => asEmptyStruct(false)).toThrow(`Unable to cast boolean to ${label}`);
-    expect(() => asEmptyStruct([])).toThrow(`Unable to cast object to ${label}`);
+    expect(() => asEmptyStruct([])).toThrow(`Unable to cast Array to ${label}`);
     expect(() => asEmptyStruct(fn)).toThrow(`Unable to cast function to ${label}`);
   });
 
@@ -90,11 +90,11 @@ describe('asOptStruct', () => {
     expect(asSimpleStruct(null)).toBeUndefined();
     expect(asSimpleStruct(undefined)).toBeUndefined();
     // should fail
-    expect(() => asSimpleStruct({})).toThrow(`Unable to cast object to ${label}`);
+    expect(() => asSimpleStruct({})).toThrow(`Unable to cast {} to ${label}`);
     expect(() => asSimpleStruct('test')).toThrow(`Unable to cast string to ${label}`);
     expect(() => asSimpleStruct(0)).toThrow(`Unable to cast number to ${label}`);
     expect(() => asSimpleStruct(false)).toThrow(`Unable to cast boolean to ${label}`);
-    expect(() => asSimpleStruct([])).toThrow(`Unable to cast object to ${label}`);
+    expect(() => asSimpleStruct([])).toThrow(`Unable to cast Array to ${label}`);
     expect(() => asSimpleStruct(fn)).toThrow(`Unable to cast function to ${label}`);
   });
 
@@ -107,13 +107,13 @@ describe('asOptStruct', () => {
     expect(asNestedStruct(null)).toBeUndefined();
     expect(asNestedStruct(undefined)).toBeUndefined();
     // should fail
-    expect(() => asNestedStruct({ value: {}})).toThrow(`Unable to cast object to ${label}`);
-    expect(() => asNestedStruct({ value: 12 })).toThrow(`Unable to cast object to ${label}`);
-    expect(() => asNestedStruct({})).toThrow(`Unable to cast object to ${label}`);
+    expect(() => asNestedStruct({ value: {}})).toThrow(`Unable to cast { value: {} } to ${label}`);
+    expect(() => asNestedStruct({ value: 12 })).toThrow(`Unable to cast { value: number } to ${label}`);
+    expect(() => asNestedStruct({})).toThrow(`Unable to cast {} to ${label}`);
     expect(() => asNestedStruct('test')).toThrow(`Unable to cast string to ${label}`);
     expect(() => asNestedStruct(0)).toThrow(`Unable to cast number to ${label}`);
     expect(() => asNestedStruct(false)).toThrow(`Unable to cast boolean to ${label}`);
-    expect(() => asNestedStruct([])).toThrow(`Unable to cast object to ${label}`);
+    expect(() => asNestedStruct([])).toThrow(`Unable to cast Array to ${label}`);
     expect(() => asNestedStruct(fn)).toThrow(`Unable to cast function to ${label}`);
   });
 });

--- a/src/type-cast/as-union.test.ts
+++ b/src/type-cast/as-union.test.ts
@@ -12,7 +12,7 @@ describe('asUnion', () => {
 
     expect(cast('hello')).toBe('hello');
     expect(cast(42)).toBe(42);
-    expect(() => cast(null)).toThrow('Unable to cast object to string | number');
+    expect(() => cast(null)).toThrow('Unable to cast null to string | number');
   });
 });
 describe('isOptUnion', () => {

--- a/src/type-cast/type-cast.ts
+++ b/src/type-cast/type-cast.ts
@@ -3,6 +3,7 @@ import type { TypeCheck } from '../TypeCheck.type';
 import type { OptionalTypeCast } from '../TypeCast.type';
 
 import { isNullish } from '../type-check/is-primitive';
+import { inspectType } from '../inspectType';
 
 export function optTypeCast<Input, Output> (isType: TypeCheck<Output>): OptionalTypeCast<Output, Optional<Input>> {
   return (obj: Optional<Input>) => {
@@ -12,7 +13,7 @@ export function optTypeCast<Input, Output> (isType: TypeCheck<Output>): Optional
     if (isType(obj)) {
       return obj;
     }
-    throw new Error(`Unable to cast ${typeof obj} to Optional<${isType.TYPE_NAME ?? 'unknown'}>`);
+    throw new Error(`Unable to cast ${inspectType(obj)} to Optional<${isType.TYPE_NAME ?? 'unknown'}>`);
   };
 }
 
@@ -24,6 +25,6 @@ export function typeCast<Output> (isType: TypeCheck<Output>): (obj: unknown, fal
     if (isNullish(obj) && typeof fallback !== 'undefined') {
       return fallback;
     }
-    throw new Error(`Unable to cast ${typeof obj} to ${isType.TYPE_NAME ?? 'unknown'}`);
+    throw new Error(`Unable to cast ${inspectType(obj)} to ${isType.TYPE_NAME ?? 'unknown'}`);
   };
 }

--- a/src/type-coerce/make-primitive.test.ts
+++ b/src/type-coerce/make-primitive.test.ts
@@ -4,11 +4,11 @@ it('makeString', () => {
   expect(makeString(42)).toBe('42');
   expect(makeString('hello')).toBe('hello');
   expect(makeString(true)).toBe('true');
-  expect(() => makeString(null)).toThrow('Unable to cast object to String');
+  expect(() => makeString(null)).toThrow('Unable to cast null to String');
   expect(() => makeString(undefined)).toThrow('Unable to cast undefined to String');
   expect(() => makeString(() => true)).toThrow('Unable to cast function to String');
-  expect(() => makeString([])).toThrow('Unable to cast object to String');
-  expect(() => makeString({})).toThrow('Unable to cast object to String');
+  expect(() => makeString([])).toThrow('Unable to cast Array to String');
+  expect(() => makeString({})).toThrow('Unable to cast {} to String');
   expect(() => makeString(Symbol('bad'))).toThrow('Unable to cast symbol to String');
 });
 
@@ -18,12 +18,12 @@ it('makeNumber', () => {
   expect(makeNumber('42')).toBe(42);
   expect(makeNumber(true)).toBe(1);
   expect(makeNumber(false)).toBe(0);
-  expect(() => makeNumber(null)).toThrow('Unable to cast object to Number');
+  expect(() => makeNumber(null)).toThrow('Unable to cast null to Number');
   expect(() => makeNumber('4four')).toThrow('Unable to cast string to Number');
   expect(() => makeNumber(undefined)).toThrow('Unable to cast undefined to Number');
   expect(() => makeNumber(() => true)).toThrow('Unable to cast function to Number');
-  expect(() => makeNumber([])).toThrow('Unable to cast object to Number');
-  expect(() => makeNumber({})).toThrow('Unable to cast object to Number');
+  expect(() => makeNumber([])).toThrow('Unable to cast Array to Number');
+  expect(() => makeNumber({})).toThrow('Unable to cast {} to Number');
   expect(() => makeNumber(Symbol('bad'))).toThrow('Unable to cast symbol to Number');
 });
 
@@ -35,10 +35,10 @@ it('makeBoolean', () => {
   expect(makeBoolean('false')).toBe(false);
   expect(makeBoolean(true)).toBe(true);
   expect(makeBoolean(false)).toBe(false);
-  expect(() => makeBoolean(null)).toThrow('Unable to cast object to Boolean');
+  expect(() => makeBoolean(null)).toThrow('Unable to cast null to Boolean');
   expect(() => makeBoolean(undefined)).toThrow('Unable to cast undefined to Boolean');
   expect(() => makeBoolean(() => true)).toThrow('Unable to cast function to Boolean');
-  expect(() => makeBoolean([])).toThrow('Unable to cast object to Boolean');
-  expect(() => makeBoolean({})).toThrow('Unable to cast object to Boolean');
+  expect(() => makeBoolean([])).toThrow('Unable to cast Array to Boolean');
+  expect(() => makeBoolean({})).toThrow('Unable to cast {} to Boolean');
   expect(() => makeBoolean(Symbol('bad'))).toThrow('Unable to cast symbol to Boolean');
 });

--- a/src/type-coerce/make-primitive.ts
+++ b/src/type-coerce/make-primitive.ts
@@ -1,3 +1,4 @@
+import { inspectType } from '../inspectType';
 import { isString, isNumber, isBoolean } from '../type-check/is-primitive';
 
 export function makeString(obj: unknown): string {
@@ -8,7 +9,7 @@ export function makeString(obj: unknown): string {
     return obj.toString();
   }
 
-  throw new Error(`Unable to cast ${typeof obj} to String`);
+  throw new Error(`Unable to cast ${inspectType(obj)} to String`);
 }
 
 export function makeNumber(obj: unknown): number {
@@ -25,7 +26,7 @@ export function makeNumber(obj: unknown): number {
     return +obj;
   }
 
-  throw new Error(`Unable to cast ${typeof obj} to Number`);
+  throw new Error(`Unable to cast ${inspectType(obj)} to Number`);
 }
 
 export function makeBoolean(obj: unknown): boolean {
@@ -44,5 +45,5 @@ export function makeBoolean(obj: unknown): boolean {
     }
   }
 
-  throw new Error(`Unable to cast ${typeof obj} to Boolean`);
+  throw new Error(`Unable to cast ${inspectType(obj)} to Boolean`);
 }


### PR DESCRIPTION
Adds a new helper function `inspectType` which inspects the type of a given value and returns a description of it as a string. Can be thought of as a much superior version of the `typeof` operator.

Also replaces our use of `typeof` within type error messages.