### PR TITLE
Depreciate the fallback parameter of type casts

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -58,6 +58,13 @@ module.exports = {
         leadingUnderscore: 'require',
         trailingUnderscore: 'forbid'
       },
+      // enforce boolean values include a specific prefix
+      {
+        selector: ["variable", "parameter"],
+        types: ["boolean"],
+        format: ["PascalCase"],
+        prefix: ["is", "should", "has", "can", "did", "will"]
+      },
       // all other variables should be camelCase
       {
         selector: ['variableLike'],

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ npm install ts-runtime-typecheck
 
 - [Installation](#installation)
 - [Type Casts](#type-casts)
-  - [Fallback values](#fallback-values)
 - [Type Checks](#type-checks)
 - [Type Coerce](#type-coerce)
 - [Type Asserts](#type-asserts)
@@ -33,29 +32,7 @@ npm install ts-runtime-typecheck
 - [Union types](#union-types)
 - [Class instances](#class-instances)
 - [Reference](#reference)
-  - [Reference: Type Casts](#reference-type-casts)
-  - [Reference: Optional Type Casts](#reference-optional-type-casts)
-  - [Reference: Type Checks](#reference-type-checks)
-  - [Reference: Optional Type Checks](#reference-optional-type-checks)
-  - [Reference: Type Coerce](#reference-type-coerce)
-  - [Reference: Type Assert](#reference-type-assert)
-  - [Reference: Helper functions](#reference-helper-functions)
-  - [Reference: Types](#reference-types)
-
 - [Changelog](#changelog)
-  - [v1.0.0](#v100)
-  - [v1.1.0](#v110)
-  - [v1.1.1](#v111)
-  - [v1.2.0](#v120)
-  - [v2.0.0](#v200)
-  - [v2.1.0](#v210)
-  - [v2.1.1](#211)
-  - [v2.2.0](#220)
-  - [v2.2.1](#221)
-  - [v2.2.2](#222)
-  - [v2.3.0](#230)
-  - [v2.4.0](#240)
-  - [v2.5.0](#250)
 
 ## Type Casts
 
@@ -79,27 +56,9 @@ square('10')
 
 **Type Casts** are meant to primarily validate questionable values that are expected to be in a well defined structure. Such as network responses, interfacing with untyped JavaScript or reading data back from a file. If you are looking to validate a type, without throwing an error then take a look at [Type Checks](#type-checks).
 
-### Fallback values
+### Optional Type Casts
 
-The standard type cast functions take a second optional parameter, which is a _fallback_ value. In the situation that the input is [`Nullish`](#nullish) and the fallback parameter has been defined the function will return the fallback parameter instead of throwing. This is very helpful for validating the input of an optional value, and providing a default value.
-
-```typescript
-import { asString } from 'ts-runtime-typecheck';
-
-function printName (name: unknown) {
-  const value: string = asString(name, 'Dave');
-  console.log(`Hello ${value}, how are you today?`);
-}
-
-printName()
-// Hello Dave, how are you today?
-printName('James')
-// Hello James, now are you today?
-printName(42)
-// Error: Unable to cast number to string
-```
-
-In the situation you want to check a value meets an [`Optional`](#optional) type there exists an alternate function for each type cast. These take the form [`asOpt{TYPE}`](#reference-optional-type-casts). Unlike the standard functions they do not allow for a fallback value, but when a [`Nullish`](#nullish) value is passed in they will always emit `undefined`. If the input is not [`Nullish`](#nullish), then it behaves the same as the standard type casts. If the type condition is met then it emits the value, otherwise it will throw.
+In the situation you want to check a value meets an [`Optional`](#optional) type there exists an alternate function for each type cast. These take the form [`asOpt{TYPE}`](#reference-optional-type-casts). Unlike the standard functions when a [`Nullish`](#nullish) value is passed in they will emit `undefined` instead of throwing. If the input is not [`Nullish`](#nullish), then it behaves the same as the standard type casts. If the type condition is met then it emits the value, otherwise it will throw.
 
 ---
 
@@ -184,7 +143,7 @@ main(42); // 'but what is the question?'
 main(); // TypeAssertion: Meaning of Life is not defined
 ```
 
-TypeAsserts cannot be based on generic types, due to limits in the TypeScript type system. Hence there is no equivalent to [`isStruct`](#isstruct) and similar [`TypeCheck`](#typecheck). However, there is an alternative. It's possible to utilise an invariant ( or assert) function with a [`TypeCheck`](#typecheck) to get the same effect, and an implementation of [`invariant`](#invariant) is provided for this purpose.
+TypeAsserts cannot be based on generic types, due to limits in the TypeScript type system. Hence there is no analogous function to [`isStruct`](#isstruct) and similar [`TypeCheck`](#typecheck). However, there is an alternative. It's possible to utilise an invariant ( or assert) function with a [`TypeCheck`](#typecheck) to get the same effect, and an implementation of [`invariant`](#invariant) is provided for this purpose.
 
 ```typescript
 import { invariant, isLiteral } from 'ts-runtime-typecheck';
@@ -262,7 +221,7 @@ const obj = asJSONValue(almost_right);
 
 ## Ensuring an optional value is defined
 
-A common situation is that you have an [`Optional`](#optional) value, with a well defined type. At a specific time it should be defined, but the type system is not aware of this. TypeScript will allow you to cast the value to a non-optional type using `!`, but this is often discouraged in style guides. As an alternative solution you can use the [`asDefined`](#asdefined) function, which removes the optionality from a type union. As with the other type casts this can take a fallback value, and will throw if the condition is not met. However, the output type matches the input type with [`Nullish`](#nullish) subtracted.
+A common situation is that you have an [`Optional`](#optional) value, with a well defined type. At a specific time it should be defined, but the type system is not aware of this. TypeScript will allow you to cast the value to a non-optional type using `!`, but this is often discouraged in style guides. As an alternative solution you can use the [`asDefined`](#asdefined) function, which removes the optionality from a type union.
 
 ```typescript
 import { asDefined } from 'ts-runtime-typecheck';
@@ -456,63 +415,63 @@ function main (n: A | B) {
 
 - ### asString
 
-  Cast `unknown` to `string`. Accepts an optional fallback value that is emitted if the value is nullish and fallback is defined.
+  Cast `unknown` to `string`.
 
 - ### asNumber
 
-  Cast `unknown` to `number`. Accepts an optional fallback value that is emitted if the value is nullish and fallback is defined.
+  Cast `unknown` to `number`.
 
 - ### asIndex
 
-  Cast `unknown` to [`Index`](#index). Accepts an optional fallback value that is emitted if the value is nullish and fallback is defined.
+  Cast `unknown` to [`Index`](#index).
 
 - ### asPrimitive
 
-  Cast `unknown` to [`Primitive`](#primitive). Accepts an optional fallback value that is emitted if the value is nullish and fallback is defined.
+  Cast `unknown` to [`Primitive`](#primitive).
 
 - ### asIndexable
 
-  Cast `unknown` to [`Indexable`](#indexable). Accepts an optional fallback value that is emitted if the value is nullish and fallback is defined.
+  Cast `unknown` to [`Indexable`](#indexable).
 
 - ### asBoolean
 
-  Cast `unknown` to `boolean`. Accepts an optional fallback value that is emitted if the value is nullish and fallback is defined.
+  Cast `unknown` to `boolean`.
 
 - ### asArray
 
-  Cast `unknown` to `Array<unknown>`. Accepts an optional fallback value that is emitted if the value is nullish and fallback is defined.
+  Cast `unknown` to `Array<unknown>`.
 
 - ### asDictionary
 
-  Cast `unknown` to [`Dictionary<unknown>`](#dictionary). Accepts an optional fallback value that is emitted if the value is nullish and fallback is defined.
+  Cast `unknown` to [`Dictionary<unknown>`](#dictionary).
 
 - ### asFunction
 
-  Cast `unknown` to [`UnknownFunction`](#unknownfunction). Accepts an optional fallback value that is emitted if the value is nullish and fallback is defined.
+  Cast `unknown` to [`UnknownFunction`](#unknownfunction).
 
 - ### asDefined
 
-  Cast [`Type | Nullish`](#nullish) to `Type`, where `Type` is a generic parameter. Accepts an optional fallback value that is emitted if the value is nullish and fallback is defined.
+  Cast [`Type | Nullish`](#nullish) to `Type`, where `Type` is a generic parameter.
 
 - ### asJSONValue
 
-  Cast `unknown` to [`JSONValue`](#jsonvalue). This function recursively validates the value, and hence will fail if given a cyclic value. Accepts an optional fallback value that is emitted if the value is nullish and fallback is defined.
+  Cast `unknown` to [`JSONValue`](#jsonvalue). This function recursively validates the value, and hence will fail if given a cyclic value.
 
 - ### asJSONObject
 
-  Cast [`JSONValue`](#jsonvalue) to [`JSONObject`](#jsonobject). Unlike [`asJSONValue`](#asjsonvalue) this does not perform recursive validation, hence it only accepts a [`JSONValue`](#jsonvalue) so that the sub-elements are of a known type. Accepts an optional fallback value that is emitted if the value is nullish and fallback is defined.
+  Cast [`JSONValue`](#jsonvalue) to [`JSONObject`](#jsonobject). Unlike [`asJSONValue`](#asjsonvalue) this does not perform recursive validation, hence it only accepts a [`JSONValue`](#jsonvalue) so that the sub-elements are of a known type.
 
 - ### asJSONArray
   
-  Cast [`JSONValue`](#jsonvalue) to [`JSONArray`](#jsonarray). Unlike [`asJSONValue`](#asjsonvalue) this does not perform recursive validation, hence it only accepts a [`JSONValue`](#jsonvalue) so that the sub-elements are of a known type. Accepts an optional fallback value that is emitted if the value is nullish and fallback is defined.
+  Cast [`JSONValue`](#jsonvalue) to [`JSONArray`](#jsonarray). Unlike [`asJSONValue`](#asjsonvalue) this does not perform recursive validation, hence it only accepts a [`JSONValue`](#jsonvalue) so that the sub-elements are of a known type.
 
 - ### asArrayOf
   
-  Takes a Type Cast function for `Type` and returns a new Type Cast function for `Array<Type>` where type is a generic parameter. The emitted Type Cast function accepts an optional fallback value that is emitted if the value is nullish and fallback is defined. Refer to [Array/Object of Type Casts](#arrayobject-of-type-casts) for examples.
+  Takes a Type Cast function for `Type` and returns a new Type Cast function for `Array<Type>` where type is a generic parameter. Refer to [Array/Object of Type Casts](#arrayobject-of-type-casts) for examples.
 
 - ### asDictionaryOf
   
-  Takes a Type Cast function for `Type` and returns a new Type Cast function for [`Dictionary<Type>`](#dictionary) where type is a generic parameter. The emitted Type Cast function accepts an optional fallback value that is emitted if the value is nullish and fallback is defined. Refer to [Array/Object of Type Casts](#arrayobject-of-type-casts) for examples.
+  Takes a Type Cast function for `Type` and returns a new Type Cast function for [`Dictionary<Type>`](#dictionary) where type is a generic parameter. Refer to [Array/Object of Type Casts](#arrayobject-of-type-casts) for examples.
 
 - ### asStruct
   
@@ -1082,3 +1041,8 @@ inspectType({ foo: 'bar' }, { maxDepth: 0 }); // Dictionary
 - Add: `inspectType` function to describe the type of a value
 - Fix: `makeNumber` no longer returns a number strings prefixed with a number
 - Change: Type error messages now use the more descriptive `inspectType` instead of `typeof` for erroneous values
+
+### 2.5.1
+
+- Change: Depreciate the fallback parameter for all TypeCasts
+- Documentation: Simplify the contents into primary headings only

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,18 @@
 {
   "name": "ts-runtime-typecheck",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@ampproject/remapping": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
+      "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "^0.3.0"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
@@ -14,32 +23,32 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.16.4",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.4.tgz",
-      "integrity": "sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q==",
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.7.tgz",
+      "integrity": "sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.7.tgz",
-      "integrity": "sha512-aeLaqcqThRNZYmbMqtulsetOQZ/5gbR/dWruUCJcpas4Qoyy+QeagfDsPdMrqwsPRDNxJvBlRiZxxX7THO7qtA==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.8.tgz",
+      "integrity": "sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==",
       "dev": true,
       "requires": {
+        "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.16.7",
-        "@babel/helper-compilation-targets": "^7.16.7",
-        "@babel/helper-module-transforms": "^7.16.7",
-        "@babel/helpers": "^7.16.7",
-        "@babel/parser": "^7.16.7",
+        "@babel/generator": "^7.17.7",
+        "@babel/helper-compilation-targets": "^7.17.7",
+        "@babel/helper-module-transforms": "^7.17.7",
+        "@babel/helpers": "^7.17.8",
+        "@babel/parser": "^7.17.8",
         "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.16.7",
-        "@babel/types": "^7.16.7",
+        "@babel/traverse": "^7.17.3",
+        "@babel/types": "^7.17.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.1.2",
-        "semver": "^6.3.0",
-        "source-map": "^0.5.0"
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "semver": {
@@ -47,22 +56,16 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
         }
       }
     },
     "@babel/generator": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.7.tgz",
-      "integrity": "sha512-/ST3Sg8MLGY5HVYmrjOgL60ENux/HfO/CsUh7y4MalThufhE/Ff/6EibFDHi4jiDCaWfJKoqbE6oTh21c5hrRg==",
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
+      "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.7",
+        "@babel/types": "^7.17.0",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -76,12 +79,12 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
-      "integrity": "sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==",
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.7.tgz",
+      "integrity": "sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.16.4",
+        "@babel/compat-data": "^7.17.7",
         "@babel/helper-validator-option": "^7.16.7",
         "browserslist": "^4.17.5",
         "semver": "^6.3.0"
@@ -143,19 +146,19 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz",
-      "integrity": "sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==",
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.7.tgz",
+      "integrity": "sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==",
       "dev": true,
       "requires": {
         "@babel/helper-environment-visitor": "^7.16.7",
         "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-simple-access": "^7.16.7",
+        "@babel/helper-simple-access": "^7.17.7",
         "@babel/helper-split-export-declaration": "^7.16.7",
         "@babel/helper-validator-identifier": "^7.16.7",
         "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.16.7",
-        "@babel/types": "^7.16.7"
+        "@babel/traverse": "^7.17.3",
+        "@babel/types": "^7.17.0"
       }
     },
     "@babel/helper-plugin-utils": {
@@ -165,12 +168,12 @@
       "dev": true
     },
     "@babel/helper-simple-access": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
-      "integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz",
+      "integrity": "sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.17.0"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -195,20 +198,20 @@
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.7.tgz",
-      "integrity": "sha512-9ZDoqtfY7AuEOt3cxchfii6C7GDyyMBffktR5B2jvWv8u2+efwvpnVKXMWzNehqy68tKgAfSwfdw/lWpthS2bw==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.8.tgz",
+      "integrity": "sha512-QcL86FGxpfSJwGtAvv4iG93UL6bmqBdmoVY0CMCU2g+oD2ezQse3PT5Pa+jiD6LJndBQi0EDlpzOWNlLuhz5gw==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.16.7",
-        "@babel/types": "^7.16.7"
+        "@babel/traverse": "^7.17.3",
+        "@babel/types": "^7.17.0"
       }
     },
     "@babel/highlight": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.7.tgz",
-      "integrity": "sha512-aKpPMfLvGO3Q97V0qhw/V2SWNWlwfJknuwAunU7wZLSfrM4xTBvg7E5opUVi1kJTBKihE38CPg4nBiqX83PWYw==",
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
+      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.16.7",
@@ -275,9 +278,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.7.tgz",
-      "integrity": "sha512-sR4eaSrnM7BV7QPzGfEX5paG/6wrZM3I0HDzfIAK06ESvo9oy3xBuVBxE3MbQaKNhvg8g/ixjMWo2CGpzpHsDA==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
+      "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
       "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
@@ -409,19 +412,19 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.7.tgz",
-      "integrity": "sha512-8KWJPIb8c2VvY8AJrydh6+fVRo2ODx1wYBU2398xJVq0JomuLBZmVQzLPBblJgHIGYG4znCpUZUZ0Pt2vdmVYQ==",
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+      "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.16.7",
+        "@babel/generator": "^7.17.3",
         "@babel/helper-environment-visitor": "^7.16.7",
         "@babel/helper-function-name": "^7.16.7",
         "@babel/helper-hoist-variables": "^7.16.7",
         "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/parser": "^7.16.7",
-        "@babel/types": "^7.16.7",
+        "@babel/parser": "^7.17.3",
+        "@babel/types": "^7.17.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -435,9 +438,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.7.tgz",
-      "integrity": "sha512-E8HuV7FO9qLpx6OtoGfUQ2cjIYnbFwvZWYBS+87EwtdMvmUPJSwykpovFB+8insbpF0uJcpr8KMUi64XZntZcg==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.16.7",
@@ -531,49 +534,49 @@
       "dev": true
     },
     "@jest/console": {
-      "version": "27.4.2",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.4.2.tgz",
-      "integrity": "sha512-xknHThRsPB/To1FUbi6pCe43y58qFC03zfb6R7fDb/FfC7k2R3i1l+izRBJf8DI46KhYGRaF14Eo9A3qbBoixg==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-27.5.1.tgz",
+      "integrity": "sha512-kZ/tNpS3NXn0mlXXXPNuDZnb4c0oZ20r4K5eemM2k30ZC3G0T02nXUvyhf5YdbXWHPEJLc9qGLxEZ216MdL+Zg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.4.2",
+        "@jest/types": "^27.5.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^27.4.2",
-        "jest-util": "^27.4.2",
+        "jest-message-util": "^27.5.1",
+        "jest-util": "^27.5.1",
         "slash": "^3.0.0"
       }
     },
     "@jest/core": {
-      "version": "27.4.5",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.4.5.tgz",
-      "integrity": "sha512-3tm/Pevmi8bDsgvo73nX8p/WPng6KWlCyScW10FPEoN1HU4pwI83tJ3TsFvi1FfzsjwUlMNEPowgb/rPau/LTQ==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-27.5.1.tgz",
+      "integrity": "sha512-AK6/UTrvQD0Cd24NSqmIA6rKsu0tKIxfiCducZvqxYdmMisOYAsdItspT+fQDQYARPf8XgjAFZi0ogW2agH5nQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.4.2",
-        "@jest/reporters": "^27.4.5",
-        "@jest/test-result": "^27.4.2",
-        "@jest/transform": "^27.4.5",
-        "@jest/types": "^27.4.2",
+        "@jest/console": "^27.5.1",
+        "@jest/reporters": "^27.5.1",
+        "@jest/test-result": "^27.5.1",
+        "@jest/transform": "^27.5.1",
+        "@jest/types": "^27.5.1",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.8.1",
         "exit": "^0.1.2",
-        "graceful-fs": "^4.2.4",
-        "jest-changed-files": "^27.4.2",
-        "jest-config": "^27.4.5",
-        "jest-haste-map": "^27.4.5",
-        "jest-message-util": "^27.4.2",
-        "jest-regex-util": "^27.4.0",
-        "jest-resolve": "^27.4.5",
-        "jest-resolve-dependencies": "^27.4.5",
-        "jest-runner": "^27.4.5",
-        "jest-runtime": "^27.4.5",
-        "jest-snapshot": "^27.4.5",
-        "jest-util": "^27.4.2",
-        "jest-validate": "^27.4.2",
-        "jest-watcher": "^27.4.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^27.5.1",
+        "jest-config": "^27.5.1",
+        "jest-haste-map": "^27.5.1",
+        "jest-message-util": "^27.5.1",
+        "jest-regex-util": "^27.5.1",
+        "jest-resolve": "^27.5.1",
+        "jest-resolve-dependencies": "^27.5.1",
+        "jest-runner": "^27.5.1",
+        "jest-runtime": "^27.5.1",
+        "jest-snapshot": "^27.5.1",
+        "jest-util": "^27.5.1",
+        "jest-validate": "^27.5.1",
+        "jest-watcher": "^27.5.1",
         "micromatch": "^4.0.4",
         "rimraf": "^3.0.0",
         "slash": "^3.0.0",
@@ -581,68 +584,68 @@
       }
     },
     "@jest/environment": {
-      "version": "27.4.4",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.4.4.tgz",
-      "integrity": "sha512-q+niMx7cJgt/t/b6dzLOh4W8Ef/8VyKG7hxASK39jakijJzbFBGpptx3RXz13FFV7OishQ9lTbv+dQ5K3EhfDQ==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.5.1.tgz",
+      "integrity": "sha512-/WQjhPJe3/ghaol/4Bq480JKXV/Rfw8nQdN7f41fM8VDHLcxKXou6QyXAh3EFr9/bVG3x74z1NWDkP87EiY8gA==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^27.4.2",
-        "@jest/types": "^27.4.2",
+        "@jest/fake-timers": "^27.5.1",
+        "@jest/types": "^27.5.1",
         "@types/node": "*",
-        "jest-mock": "^27.4.2"
+        "jest-mock": "^27.5.1"
       }
     },
     "@jest/fake-timers": {
-      "version": "27.4.2",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.4.2.tgz",
-      "integrity": "sha512-f/Xpzn5YQk5adtqBgvw1V6bF8Nx3hY0OIRRpCvWcfPl0EAjdqWPdhH3t/3XpiWZqtjIEHDyMKP9ajpva1l4Zmg==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-27.5.1.tgz",
+      "integrity": "sha512-/aPowoolwa07k7/oM3aASneNeBGCmGQsc3ugN4u6s4C/+s5M64MFo/+djTdiwcbQlRfFElGuDXWzaWj6QgKObQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.4.2",
+        "@jest/types": "^27.5.1",
         "@sinonjs/fake-timers": "^8.0.1",
         "@types/node": "*",
-        "jest-message-util": "^27.4.2",
-        "jest-mock": "^27.4.2",
-        "jest-util": "^27.4.2"
+        "jest-message-util": "^27.5.1",
+        "jest-mock": "^27.5.1",
+        "jest-util": "^27.5.1"
       }
     },
     "@jest/globals": {
-      "version": "27.4.4",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.4.4.tgz",
-      "integrity": "sha512-bqpqQhW30BOreXM8bA8t8JbOQzsq/WnPTnBl+It3UxAD9J8yxEAaBEylHx1dtBapAr/UBk8GidXbzmqnee8tYQ==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.5.1.tgz",
+      "integrity": "sha512-ZEJNB41OBQQgGzgyInAv0UUfDDj3upmHydjieSxFvTRuZElrx7tXg/uVQ5hYVEwiXs3+aMsAeEc9X7xiSKCm4Q==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.4.4",
-        "@jest/types": "^27.4.2",
-        "expect": "^27.4.2"
+        "@jest/environment": "^27.5.1",
+        "@jest/types": "^27.5.1",
+        "expect": "^27.5.1"
       }
     },
     "@jest/reporters": {
-      "version": "27.4.5",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.4.5.tgz",
-      "integrity": "sha512-3orsG4vi8zXuBqEoy2LbnC1kuvkg1KQUgqNxmxpQgIOQEPeV0onvZu+qDQnEoX8qTQErtqn/xzcnbpeTuOLSiA==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-27.5.1.tgz",
+      "integrity": "sha512-cPXh9hWIlVJMQkVk84aIvXuBB4uQQmFqZiacloFuGiP3ah1sbCxCosidXFDfqG8+6fO1oR2dTJTlsOy4VFmUfw==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^27.4.2",
-        "@jest/test-result": "^27.4.2",
-        "@jest/transform": "^27.4.5",
-        "@jest/types": "^27.4.2",
+        "@jest/console": "^27.5.1",
+        "@jest/test-result": "^27.5.1",
+        "@jest/transform": "^27.5.1",
+        "@jest/types": "^27.5.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
         "glob": "^7.1.2",
-        "graceful-fs": "^4.2.4",
+        "graceful-fs": "^4.2.9",
         "istanbul-lib-coverage": "^3.0.0",
-        "istanbul-lib-instrument": "^4.0.3",
+        "istanbul-lib-instrument": "^5.1.0",
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
-        "istanbul-reports": "^3.0.2",
-        "jest-haste-map": "^27.4.5",
-        "jest-resolve": "^27.4.5",
-        "jest-util": "^27.4.2",
-        "jest-worker": "^27.4.5",
+        "istanbul-reports": "^3.1.3",
+        "jest-haste-map": "^27.5.1",
+        "jest-resolve": "^27.5.1",
+        "jest-util": "^27.5.1",
+        "jest-worker": "^27.5.1",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -651,67 +654,67 @@
       }
     },
     "@jest/source-map": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-27.4.0.tgz",
-      "integrity": "sha512-Ntjx9jzP26Bvhbm93z/AKcPRj/9wrkI88/gK60glXDx1q+IeI0rf7Lw2c89Ch6ofonB0On/iRDreQuQ6te9pgQ==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-27.5.1.tgz",
+      "integrity": "sha512-y9NIHUYF3PJRlHk98NdC/N1gl88BL08aQQgu4k4ZopQkCw9t9cV8mtl3TV8b/YCB8XaVTFrmUTAJvjsntDireg==",
       "dev": true,
       "requires": {
         "callsites": "^3.0.0",
-        "graceful-fs": "^4.2.4",
+        "graceful-fs": "^4.2.9",
         "source-map": "^0.6.0"
       }
     },
     "@jest/test-result": {
-      "version": "27.4.2",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.4.2.tgz",
-      "integrity": "sha512-kr+bCrra9jfTgxHXHa2UwoQjxvQk3Am6QbpAiJ5x/50LW8llOYrxILkqY0lZRW/hu8FXesnudbql263+EW9iNA==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-27.5.1.tgz",
+      "integrity": "sha512-EW35l2RYFUcUQxFJz5Cv5MTOxlJIQs4I7gxzi2zVU7PJhOwfYq1MdC5nhSmYjX1gmMmLPvB3sIaC+BkcHRBfag==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.4.2",
-        "@jest/types": "^27.4.2",
+        "@jest/console": "^27.5.1",
+        "@jest/types": "^27.5.1",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       }
     },
     "@jest/test-sequencer": {
-      "version": "27.4.5",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.4.5.tgz",
-      "integrity": "sha512-n5woIn/1v+FT+9hniymHPARA9upYUmfi5Pw9ewVwXCDlK4F5/Gkees9v8vdjGdAIJ2MPHLHodiajLpZZanWzEQ==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-27.5.1.tgz",
+      "integrity": "sha512-LCheJF7WB2+9JuCS7VB/EmGIdQuhtqjRNI9A43idHv3E4KltCTsPsLxvdaubFHSYwY/fNjMWjl6vNRhDiN7vpQ==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^27.4.2",
-        "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.4.5",
-        "jest-runtime": "^27.4.5"
+        "@jest/test-result": "^27.5.1",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^27.5.1",
+        "jest-runtime": "^27.5.1"
       }
     },
     "@jest/transform": {
-      "version": "27.4.5",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.4.5.tgz",
-      "integrity": "sha512-PuMet2UlZtlGzwc6L+aZmR3I7CEBpqadO03pU40l2RNY2fFJ191b9/ITB44LNOhVtsyykx0OZvj0PCyuLm7Eew==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-27.5.1.tgz",
+      "integrity": "sha512-ipON6WtYgl/1329g5AIJVbUuEh0wZVbdpGwC99Jw4LwuoBNS95MVphU6zOeD9pDkon+LLbFL7lOQRapbB8SCHw==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/types": "^27.4.2",
-        "babel-plugin-istanbul": "^6.0.0",
+        "@jest/types": "^27.5.1",
+        "babel-plugin-istanbul": "^6.1.1",
         "chalk": "^4.0.0",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.0.0",
-        "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.4.5",
-        "jest-regex-util": "^27.4.0",
-        "jest-util": "^27.4.2",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^27.5.1",
+        "jest-regex-util": "^27.5.1",
+        "jest-util": "^27.5.1",
         "micromatch": "^4.0.4",
-        "pirates": "^4.0.1",
+        "pirates": "^4.0.4",
         "slash": "^3.0.0",
         "source-map": "^0.6.1",
         "write-file-atomic": "^3.0.0"
       }
     },
     "@jest/types": {
-      "version": "27.4.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.4.2.tgz",
-      "integrity": "sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
+      "integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -719,6 +722,28 @@
         "@types/node": "*",
         "@types/yargs": "^16.0.0",
         "chalk": "^4.0.0"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
+      "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
+      "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
+      "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "@nodelib/fs.scandir": {
@@ -782,9 +807,9 @@
       "dev": true
     },
     "@types/babel__core": {
-      "version": "7.1.18",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.18.tgz",
-      "integrity": "sha512-S7unDjm/C7z2A2R9NzfKCK1I+BAALDtxEmsJBwlB3EzNfb929ykjL++1CK9LO++EIp2fQrC8O+BwjKvz6UeDyQ==",
+      "version": "7.1.19",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.19.tgz",
+      "integrity": "sha512-WEOTgRsbYkvA/KCsDwVEGkd7WAr1e3g31VHQ8zy5gul/V1qKullU/BU5I68X5v7V3GnB9eotmom4v5a5gjxorw==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -872,15 +897,15 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.7.tgz",
-      "integrity": "sha512-1QUk+WAUD4t8iR+Oj+UgI8oJa6yyxaB8a8pHaC8uqM6RrS1qbL7bf3Pwl5rHv0psm2CuDErgho6v5N+G+5fwtQ==",
+      "version": "17.0.23",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
+      "integrity": "sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==",
       "dev": true
     },
     "@types/prettier": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.2.tgz",
-      "integrity": "sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.4.tgz",
+      "integrity": "sha512-ReVR2rLTV1kvtlWFyuot+d1pkpG2Fw/XKE3PDAdj57rbM97ttSp9JZ2UsP+2EHTylra9cUf6JA7tGwW1INzUrA==",
       "dev": true
     },
     "@types/stack-utils": {
@@ -899,9 +924,9 @@
       }
     },
     "@types/yargs-parser": {
-      "version": "20.2.1",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
-      "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
+      "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -1188,18 +1213,18 @@
       "dev": true
     },
     "babel-jest": {
-      "version": "27.4.5",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.4.5.tgz",
-      "integrity": "sha512-3uuUTjXbgtODmSv/DXO9nZfD52IyC2OYTFaXGRzL0kpykzroaquCrD5+lZNafTvZlnNqZHt5pb0M08qVBZnsnA==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.5.1.tgz",
+      "integrity": "sha512-cdQ5dXjGRd0IBRATiQ4mZGlGlRE8kJpjPOixdNRdT+m3UcNqmYWN6rK6nvtXYfY3D76cb8s/O1Ss8ea24PIwcg==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^27.4.5",
-        "@jest/types": "^27.4.2",
+        "@jest/transform": "^27.5.1",
+        "@jest/types": "^27.5.1",
         "@types/babel__core": "^7.1.14",
-        "babel-plugin-istanbul": "^6.0.0",
-        "babel-preset-jest": "^27.4.0",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^27.5.1",
         "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.4",
+        "graceful-fs": "^4.2.9",
         "slash": "^3.0.0"
       }
     },
@@ -1214,33 +1239,12 @@
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-instrument": "^5.0.4",
         "test-exclude": "^6.0.0"
-      },
-      "dependencies": {
-        "istanbul-lib-instrument": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.1.0.tgz",
-          "integrity": "sha512-czwUz525rkOFDJxfKK6mYfIs9zBKILyrZQxjz3ABhjQXhbhFsSbo1HW/BFcsDnfJYJWA6thRR5/TUY2qs5W99Q==",
-          "dev": true,
-          "requires": {
-            "@babel/core": "^7.12.3",
-            "@babel/parser": "^7.14.7",
-            "@istanbuljs/schema": "^0.1.2",
-            "istanbul-lib-coverage": "^3.2.0",
-            "semver": "^6.3.0"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.4.0.tgz",
-      "integrity": "sha512-Jcu7qS4OX5kTWBc45Hz7BMmgXuJqRnhatqpUhnzGC3OBYpOmf2tv6jFNwZpwM7wU7MUuv2r9IPS/ZlYOuburVw==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.5.1.tgz",
+      "integrity": "sha512-50wCwD5EMNW4aRpOwtqzyZHIewTYNxLA4nhB+09d8BIssfNfzBRhkBIHiaPv1Si226TQSvp8gxAJm2iY2qs2hQ==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.3.3",
@@ -1270,12 +1274,12 @@
       }
     },
     "babel-preset-jest": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.4.0.tgz",
-      "integrity": "sha512-NK4jGYpnBvNxcGo7/ZpZJr51jCGT+3bwwpVIDY2oNfTxJJldRtB4VAcYdgp1loDE50ODuTu+yBjpMAswv5tlpg==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-27.5.1.tgz",
+      "integrity": "sha512-Nptf2FzlPCWYuJg41HBqXVT8ym6bXOevuCTbhxlUpjwtysGaIWFvDEjp4y+G7fl13FgOdjs7P/DmErqH7da0Ag==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "^27.4.0",
+        "babel-plugin-jest-hoist": "^27.5.1",
         "babel-preset-current-node-syntax": "^1.0.0"
       }
     },
@@ -1311,15 +1315,15 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
-      "integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
+      "version": "4.20.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
+      "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001286",
-        "electron-to-chromium": "^1.4.17",
+        "caniuse-lite": "^1.0.30001317",
+        "electron-to-chromium": "^1.4.84",
         "escalade": "^3.1.1",
-        "node-releases": "^2.0.1",
+        "node-releases": "^2.0.2",
         "picocolors": "^1.0.0"
       }
     },
@@ -1360,9 +1364,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001296",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001296.tgz",
-      "integrity": "sha512-WfrtPEoNSoeATDlf4y3QvkwiELl9GyPLISV5GejTbbQRtQx4LhsXmc9IQ6XCL2d7UxCyEzToEZNMeqR79OUw8Q==",
+      "version": "1.0.30001323",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001323.tgz",
+      "integrity": "sha512-e4BF2RlCVELKx8+RmklSEIVub1TWrmdhvA5kEUueummz1XyySW0DVk+3x9HyhU9MuWTa2BhqLgEuEmUwASAdCA==",
       "dev": true
     },
     "chalk": {
@@ -1507,9 +1511,9 @@
       }
     },
     "debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -1552,9 +1556,9 @@
       "dev": true
     },
     "diff-sequences": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.4.0.tgz",
-      "integrity": "sha512-YqiQzkrsmHMH5uuh8OdQFU9/ZpADnwzml8z0O5HvRNda+5UZsaX/xN+AAxfR2hWq1Y7HZnAzO9J5lJXOuDz2Ww==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
+      "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
       "dev": true
     },
     "dir-glob": {
@@ -1593,9 +1597,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.34",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.34.tgz",
-      "integrity": "sha512-B7g6Y9No9XMYk1VNrQ8KAmSEo1Iltrz/5EjOGxl1DffQAb3z/XbpHRCfYKwV8D+CPXm4Q7Xg1sceSt9osNwRIA==",
+      "version": "1.4.103",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.103.tgz",
+      "integrity": "sha512-c/uKWR1Z/W30Wy/sx3dkZoj4BijbXX85QKWu9jJfjho3LBAXNEGAEW3oWiGb+dotA6C6BzCTxL2/aLes7jlUeg==",
       "dev": true
     },
     "emittery": {
@@ -1609,6 +1613,15 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
     },
     "escalade": {
       "version": "3.1.1",
@@ -1878,25 +1891,15 @@
       "dev": true
     },
     "expect": {
-      "version": "27.4.2",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-27.4.2.tgz",
-      "integrity": "sha512-BjAXIDC6ZOW+WBFNg96J22D27Nq5ohn+oGcuP2rtOtcjuxNoV9McpQ60PcQWhdFOSBIQdR72e+4HdnbZTFSTyg==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-27.5.1.tgz",
+      "integrity": "sha512-E1q5hSUG2AmYQwQJ041nvgpkODHQvB+RKlB4IYdru6uJsyFTRyZAP463M+1lINorwbqAmUggi6+WwkD8lCS/Dw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.4.2",
-        "ansi-styles": "^5.0.0",
-        "jest-get-type": "^27.4.0",
-        "jest-matcher-utils": "^27.4.2",
-        "jest-message-util": "^27.4.2",
-        "jest-regex-util": "^27.4.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
-        }
+        "@jest/types": "^27.5.1",
+        "jest-get-type": "^27.5.1",
+        "jest-matcher-utils": "^27.5.1",
+        "jest-message-util": "^27.5.1"
       }
     },
     "fast-deep-equal": {
@@ -2129,9 +2132,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
-      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+      "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
       "dev": true
     },
     "has": {
@@ -2217,9 +2220,9 @@
       }
     },
     "import-local": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.3.tgz",
-      "integrity": "sha512-bE9iaUY3CXH8Cwfan/abDKAxe1KGT9kyGsBPqf6DMK/z0a2OzAsrukeYNgIH6cH5Xr452jb1TUL8rSfCLjZ9uA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
+      "integrity": "sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==",
       "dev": true,
       "requires": {
         "pkg-dir": "^4.2.0",
@@ -2248,10 +2251,16 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
     "is-core-module": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
-      "integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -2321,14 +2330,15 @@
       "dev": true
     },
     "istanbul-lib-instrument": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
-      "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.1.0.tgz",
+      "integrity": "sha512-czwUz525rkOFDJxfKK6mYfIs9zBKILyrZQxjz3ABhjQXhbhFsSbo1HW/BFcsDnfJYJWA6thRR5/TUY2qs5W99Q==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.7.5",
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
         "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-coverage": "^3.2.0",
         "semver": "^6.3.0"
       },
       "dependencies": {
@@ -2363,9 +2373,9 @@
       }
     },
     "istanbul-reports": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.3.tgz",
-      "integrity": "sha512-x9LtDVtfm/t1GFiLl3NffC7hz+I1ragvgX1P/Lg1NlIagifZDKUkuuaAxH/qpwj2IuEfD8G2Bs/UKp+sZ/pKkg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.4.tgz",
+      "integrity": "sha512-r1/DshN4KSE7xWEknZLLLLDn5CJybV3nw01VTkp6D5jzLuELlcbudfj/eSQFvrKsJuTVCGnePO7ho82Nw9zzfw==",
       "dev": true,
       "requires": {
         "html-escaper": "^2.0.0",
@@ -2373,32 +2383,32 @@
       }
     },
     "jest": {
-      "version": "27.4.5",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-27.4.5.tgz",
-      "integrity": "sha512-uT5MiVN3Jppt314kidCk47MYIRilJjA/l2mxwiuzzxGUeJIvA8/pDaJOAX5KWvjAo7SCydcW0/4WEtgbLMiJkg==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
+      "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
       "dev": true,
       "requires": {
-        "@jest/core": "^27.4.5",
+        "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
-        "jest-cli": "^27.4.5"
+        "jest-cli": "^27.5.1"
       },
       "dependencies": {
         "jest-cli": {
-          "version": "27.4.5",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.4.5.tgz",
-          "integrity": "sha512-hrky3DSgE0u7sQxaCL7bdebEPHx5QzYmrGuUjaPLmPE8jx5adtvGuOlRspvMoVLTTDOHRnZDoRLYJuA+VCI7Hg==",
+          "version": "27.5.1",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-27.5.1.tgz",
+          "integrity": "sha512-Hc6HOOwYq4/74/c62dEE3r5elx8wjYqxY0r0G/nFrLDPMFRu6RA/u8qINOIkvhxG7mMQ5EJsOGfRpI8L6eFUVw==",
           "dev": true,
           "requires": {
-            "@jest/core": "^27.4.5",
-            "@jest/test-result": "^27.4.2",
-            "@jest/types": "^27.4.2",
+            "@jest/core": "^27.5.1",
+            "@jest/test-result": "^27.5.1",
+            "@jest/types": "^27.5.1",
             "chalk": "^4.0.0",
             "exit": "^0.1.2",
-            "graceful-fs": "^4.2.4",
+            "graceful-fs": "^4.2.9",
             "import-local": "^3.0.2",
-            "jest-config": "^27.4.5",
-            "jest-util": "^27.4.2",
-            "jest-validate": "^27.4.2",
+            "jest-config": "^27.5.1",
+            "jest-util": "^27.5.1",
+            "jest-validate": "^27.5.1",
             "prompts": "^2.0.1",
             "yargs": "^16.2.0"
           }
@@ -2406,235 +2416,236 @@
       }
     },
     "jest-changed-files": {
-      "version": "27.4.2",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.4.2.tgz",
-      "integrity": "sha512-/9x8MjekuzUQoPjDHbBiXbNEBauhrPU2ct7m8TfCg69ywt1y/N+yYwGh3gCpnqUS3klYWDU/lSNgv+JhoD2k1A==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-27.5.1.tgz",
+      "integrity": "sha512-buBLMiByfWGCoMsLLzGUUSpAmIAGnbR2KJoMN10ziLhOLvP4e0SlypHnAel8iqQXTrcbmfEY9sSqae5sgUsTvw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.4.2",
+        "@jest/types": "^27.5.1",
         "execa": "^5.0.0",
         "throat": "^6.0.1"
       }
     },
     "jest-circus": {
-      "version": "27.4.5",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.4.5.tgz",
-      "integrity": "sha512-eTNWa9wsvBwPykhMMShheafbwyakcdHZaEYh5iRrQ0PFJxkDP/e3U/FvzGuKWu2WpwUA3C3hPlfpuzvOdTVqnw==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-27.5.1.tgz",
+      "integrity": "sha512-D95R7x5UtlMA5iBYsOHFFbMD/GVA4R/Kdq15f7xYWUfWHBto9NYRsOvnSauTgdF+ogCpJ4tyKOXhUifxS65gdw==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.4.4",
-        "@jest/test-result": "^27.4.2",
-        "@jest/types": "^27.4.2",
+        "@jest/environment": "^27.5.1",
+        "@jest/test-result": "^27.5.1",
+        "@jest/types": "^27.5.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
         "dedent": "^0.7.0",
-        "expect": "^27.4.2",
+        "expect": "^27.5.1",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.4.2",
-        "jest-matcher-utils": "^27.4.2",
-        "jest-message-util": "^27.4.2",
-        "jest-runtime": "^27.4.5",
-        "jest-snapshot": "^27.4.5",
-        "jest-util": "^27.4.2",
-        "pretty-format": "^27.4.2",
+        "jest-each": "^27.5.1",
+        "jest-matcher-utils": "^27.5.1",
+        "jest-message-util": "^27.5.1",
+        "jest-runtime": "^27.5.1",
+        "jest-snapshot": "^27.5.1",
+        "jest-util": "^27.5.1",
+        "pretty-format": "^27.5.1",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3",
         "throat": "^6.0.1"
       }
     },
     "jest-config": {
-      "version": "27.4.5",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.4.5.tgz",
-      "integrity": "sha512-t+STVJtPt+fpqQ8GBw850NtSQbnDOw/UzdPfzDaHQ48/AylQlW7LHj3dH+ndxhC1UxJ0Q3qkq7IH+nM1skwTwA==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-27.5.1.tgz",
+      "integrity": "sha512-5sAsjm6tGdsVbW9ahcChPAFCk4IlkQUknH5AvKjuLTSlcO/wCZKyFdn7Rg0EkC+OGgWODEy2hDpWB1PgzH0JNA==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^27.4.5",
-        "@jest/types": "^27.4.2",
-        "babel-jest": "^27.4.5",
+        "@babel/core": "^7.8.0",
+        "@jest/test-sequencer": "^27.5.1",
+        "@jest/types": "^27.5.1",
+        "babel-jest": "^27.5.1",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.1",
-        "graceful-fs": "^4.2.4",
-        "jest-circus": "^27.4.5",
-        "jest-environment-jsdom": "^27.4.4",
-        "jest-environment-node": "^27.4.4",
-        "jest-get-type": "^27.4.0",
-        "jest-jasmine2": "^27.4.5",
-        "jest-regex-util": "^27.4.0",
-        "jest-resolve": "^27.4.5",
-        "jest-runner": "^27.4.5",
-        "jest-util": "^27.4.2",
-        "jest-validate": "^27.4.2",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^27.5.1",
+        "jest-environment-jsdom": "^27.5.1",
+        "jest-environment-node": "^27.5.1",
+        "jest-get-type": "^27.5.1",
+        "jest-jasmine2": "^27.5.1",
+        "jest-regex-util": "^27.5.1",
+        "jest-resolve": "^27.5.1",
+        "jest-runner": "^27.5.1",
+        "jest-util": "^27.5.1",
+        "jest-validate": "^27.5.1",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.4.2",
-        "slash": "^3.0.0"
+        "parse-json": "^5.2.0",
+        "pretty-format": "^27.5.1",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
       }
     },
     "jest-diff": {
-      "version": "27.4.2",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.4.2.tgz",
-      "integrity": "sha512-ujc9ToyUZDh9KcqvQDkk/gkbf6zSaeEg9AiBxtttXW59H/AcqEYp1ciXAtJp+jXWva5nAf/ePtSsgWwE5mqp4Q==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.5.1.tgz",
+      "integrity": "sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^27.4.0",
-        "jest-get-type": "^27.4.0",
-        "pretty-format": "^27.4.2"
+        "diff-sequences": "^27.5.1",
+        "jest-get-type": "^27.5.1",
+        "pretty-format": "^27.5.1"
       }
     },
     "jest-docblock": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-27.4.0.tgz",
-      "integrity": "sha512-7TBazUdCKGV7svZ+gh7C8esAnweJoG+SvcF6Cjqj4l17zA2q1cMwx2JObSioubk317H+cjcHgP+7fTs60paulg==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-27.5.1.tgz",
+      "integrity": "sha512-rl7hlABeTsRYxKiUfpHrQrG4e2obOiTQWfMEH3PxPjOtdsfLQO4ReWSZaQ7DETm4xu07rl4q/h4zcKXyU0/OzQ==",
       "dev": true,
       "requires": {
         "detect-newline": "^3.0.0"
       }
     },
     "jest-each": {
-      "version": "27.4.2",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.4.2.tgz",
-      "integrity": "sha512-53V2MNyW28CTruB3lXaHNk6PkiIFuzdOC9gR3C6j8YE/ACfrPnz+slB0s17AgU1TtxNzLuHyvNlLJ+8QYw9nBg==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-27.5.1.tgz",
+      "integrity": "sha512-1Ff6p+FbhT/bXQnEouYy00bkNSY7OUpfIcmdl8vZ31A1UUaurOLPA8a8BbJOF2RDUElwJhmeaV7LnagI+5UwNQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.4.2",
+        "@jest/types": "^27.5.1",
         "chalk": "^4.0.0",
-        "jest-get-type": "^27.4.0",
-        "jest-util": "^27.4.2",
-        "pretty-format": "^27.4.2"
+        "jest-get-type": "^27.5.1",
+        "jest-util": "^27.5.1",
+        "pretty-format": "^27.5.1"
       }
     },
     "jest-environment-jsdom": {
-      "version": "27.4.4",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.4.4.tgz",
-      "integrity": "sha512-cYR3ndNfHBqQgFvS1RL7dNqSvD//K56j/q1s2ygNHcfTCAp12zfIromO1w3COmXrxS8hWAh7+CmZmGCIoqGcGA==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-27.5.1.tgz",
+      "integrity": "sha512-TFBvkTC1Hnnnrka/fUb56atfDtJ9VMZ94JkjTbggl1PEpwrYtUBKMezB3inLmWqQsXYLcMwNoDQwoBTAvFfsfw==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.4.4",
-        "@jest/fake-timers": "^27.4.2",
-        "@jest/types": "^27.4.2",
+        "@jest/environment": "^27.5.1",
+        "@jest/fake-timers": "^27.5.1",
+        "@jest/types": "^27.5.1",
         "@types/node": "*",
-        "jest-mock": "^27.4.2",
-        "jest-util": "^27.4.2",
+        "jest-mock": "^27.5.1",
+        "jest-util": "^27.5.1",
         "jsdom": "^16.6.0"
       }
     },
     "jest-environment-node": {
-      "version": "27.4.4",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.4.4.tgz",
-      "integrity": "sha512-D+v3lbJ2GjQTQR23TK0kY3vFVmSeea05giInI41HHOaJnAwOnmUHTZgUaZL+VxUB43pIzoa7PMwWtCVlIUoVoA==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-27.5.1.tgz",
+      "integrity": "sha512-Jt4ZUnxdOsTGwSRAfKEnE6BcwsSPNOijjwifq5sDFSA2kesnXTvNqKHYgM0hDq3549Uf/KzdXNYn4wMZJPlFLw==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^27.4.4",
-        "@jest/fake-timers": "^27.4.2",
-        "@jest/types": "^27.4.2",
+        "@jest/environment": "^27.5.1",
+        "@jest/fake-timers": "^27.5.1",
+        "@jest/types": "^27.5.1",
         "@types/node": "*",
-        "jest-mock": "^27.4.2",
-        "jest-util": "^27.4.2"
+        "jest-mock": "^27.5.1",
+        "jest-util": "^27.5.1"
       }
     },
     "jest-get-type": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.4.0.tgz",
-      "integrity": "sha512-tk9o+ld5TWq41DkK14L4wox4s2D9MtTpKaAVzXfr5CUKm5ZK2ExcaFE0qls2W71zE/6R2TxxrK9w2r6svAFDBQ==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
+      "integrity": "sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==",
       "dev": true
     },
     "jest-haste-map": {
-      "version": "27.4.5",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.4.5.tgz",
-      "integrity": "sha512-oJm1b5qhhPs78K24EDGifWS0dELYxnoBiDhatT/FThgB9yxqUm5F6li3Pv+Q+apMBmmPNzOBnZ7ZxWMB1Leq1Q==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-27.5.1.tgz",
+      "integrity": "sha512-7GgkZ4Fw4NFbMSDSpZwXeBiIbx+t/46nJ2QitkOjvwPYyZmqttu2TDSimMHP1EkPOi4xUZAN1doE5Vd25H4Jng==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.4.2",
+        "@jest/types": "^27.5.1",
         "@types/graceful-fs": "^4.1.2",
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
         "fsevents": "^2.3.2",
-        "graceful-fs": "^4.2.4",
-        "jest-regex-util": "^27.4.0",
-        "jest-serializer": "^27.4.0",
-        "jest-util": "^27.4.2",
-        "jest-worker": "^27.4.5",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^27.5.1",
+        "jest-serializer": "^27.5.1",
+        "jest-util": "^27.5.1",
+        "jest-worker": "^27.5.1",
         "micromatch": "^4.0.4",
         "walker": "^1.0.7"
       }
     },
     "jest-jasmine2": {
-      "version": "27.4.5",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.4.5.tgz",
-      "integrity": "sha512-oUnvwhJDj2LhOiUB1kdnJjkx8C5PwgUZQb9urF77mELH9DGR4e2GqpWQKBOYXWs5+uTN9BGDqRz3Aeg5Wts7aw==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-27.5.1.tgz",
+      "integrity": "sha512-jtq7VVyG8SqAorDpApwiJJImd0V2wv1xzdheGHRGyuT7gZm6gG47QEskOlzsN1PG/6WNaCo5pmwMHDf3AkG2pQ==",
       "dev": true,
       "requires": {
-        "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^27.4.4",
-        "@jest/source-map": "^27.4.0",
-        "@jest/test-result": "^27.4.2",
-        "@jest/types": "^27.4.2",
+        "@jest/environment": "^27.5.1",
+        "@jest/source-map": "^27.5.1",
+        "@jest/test-result": "^27.5.1",
+        "@jest/types": "^27.5.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
-        "expect": "^27.4.2",
+        "expect": "^27.5.1",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^27.4.2",
-        "jest-matcher-utils": "^27.4.2",
-        "jest-message-util": "^27.4.2",
-        "jest-runtime": "^27.4.5",
-        "jest-snapshot": "^27.4.5",
-        "jest-util": "^27.4.2",
-        "pretty-format": "^27.4.2",
+        "jest-each": "^27.5.1",
+        "jest-matcher-utils": "^27.5.1",
+        "jest-message-util": "^27.5.1",
+        "jest-runtime": "^27.5.1",
+        "jest-snapshot": "^27.5.1",
+        "jest-util": "^27.5.1",
+        "pretty-format": "^27.5.1",
         "throat": "^6.0.1"
       }
     },
     "jest-leak-detector": {
-      "version": "27.4.2",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.4.2.tgz",
-      "integrity": "sha512-ml0KvFYZllzPBJWDei3mDzUhyp/M4ubKebX++fPaudpe8OsxUE+m+P6ciVLboQsrzOCWDjE20/eXew9QMx/VGw==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-27.5.1.tgz",
+      "integrity": "sha512-POXfWAMvfU6WMUXftV4HolnJfnPOGEu10fscNCA76KBpRRhcMN2c8d3iT2pxQS3HLbA+5X4sOUPzYO2NUyIlHQ==",
       "dev": true,
       "requires": {
-        "jest-get-type": "^27.4.0",
-        "pretty-format": "^27.4.2"
+        "jest-get-type": "^27.5.1",
+        "pretty-format": "^27.5.1"
       }
     },
     "jest-matcher-utils": {
-      "version": "27.4.2",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.4.2.tgz",
-      "integrity": "sha512-jyP28er3RRtMv+fmYC/PKG8wvAmfGcSNproVTW2Y0P/OY7/hWUOmsPfxN1jOhM+0u2xU984u2yEagGivz9OBGQ==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz",
+      "integrity": "sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^27.4.2",
-        "jest-get-type": "^27.4.0",
-        "pretty-format": "^27.4.2"
+        "jest-diff": "^27.5.1",
+        "jest-get-type": "^27.5.1",
+        "pretty-format": "^27.5.1"
       }
     },
     "jest-message-util": {
-      "version": "27.4.2",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.4.2.tgz",
-      "integrity": "sha512-OMRqRNd9E0DkBLZpFtZkAGYOXl6ZpoMtQJWTAREJKDOFa0M6ptB7L67tp+cszMBkvSgKOhNtQp2Vbcz3ZZKo/w==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.5.1.tgz",
+      "integrity": "sha512-rMyFe1+jnyAAf+NHwTclDz0eAaLkVDdKVHHBFWsBWHnnh5YeJMNWWsv7AbFYXfK3oTqvL7VTWkhNLu1jX24D+g==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^27.4.2",
+        "@jest/types": "^27.5.1",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.4",
+        "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.4.2",
+        "pretty-format": "^27.5.1",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       }
     },
     "jest-mock": {
-      "version": "27.4.2",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.4.2.tgz",
-      "integrity": "sha512-PDDPuyhoukk20JrQKeofK12hqtSka7mWH0QQuxSNgrdiPsrnYYLS6wbzu/HDlxZRzji5ylLRULeuI/vmZZDrYA==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-27.5.1.tgz",
+      "integrity": "sha512-K4jKbY1d4ENhbrG2zuPWaQBvDly+iZ2yAW+T1fATN78hc0sInwn7wZB8XtlNnvHug5RMwV897Xm4LqmPM4e2Og==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.4.2",
+        "@jest/types": "^27.5.1",
         "@types/node": "*"
       }
     },
@@ -2645,172 +2656,165 @@
       "dev": true
     },
     "jest-regex-util": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.4.0.tgz",
-      "integrity": "sha512-WeCpMpNnqJYMQoOjm1nTtsgbR4XHAk1u00qDoNBQoykM280+/TmgA5Qh5giC1ecy6a5d4hbSsHzpBtu5yvlbEg==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-27.5.1.tgz",
+      "integrity": "sha512-4bfKq2zie+x16okqDXjXn9ql2B0dScQu+vcwe4TvFVhkVyuWLqpZrZtXxLLWoXYgn0E87I6r6GRYHF7wFZBUvg==",
       "dev": true
     },
     "jest-resolve": {
-      "version": "27.4.5",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.4.5.tgz",
-      "integrity": "sha512-xU3z1BuOz/hUhVUL+918KqUgK+skqOuUsAi7A+iwoUldK6/+PW+utK8l8cxIWT9AW7IAhGNXjSAh1UYmjULZZw==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-27.5.1.tgz",
+      "integrity": "sha512-FFDy8/9E6CV83IMbDpcjOhumAQPDyETnU2KZ1O98DwTnz8AOBsW/Xv3GySr1mOZdItLR+zDZ7I/UdTFbgSOVCw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.4.2",
+        "@jest/types": "^27.5.1",
         "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.4.5",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^27.5.1",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^27.4.2",
-        "jest-validate": "^27.4.2",
+        "jest-util": "^27.5.1",
+        "jest-validate": "^27.5.1",
         "resolve": "^1.20.0",
         "resolve.exports": "^1.1.0",
         "slash": "^3.0.0"
       }
     },
     "jest-resolve-dependencies": {
-      "version": "27.4.5",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.4.5.tgz",
-      "integrity": "sha512-elEVvkvRK51y037NshtEkEnukMBWvlPzZHiL847OrIljJ8yIsujD2GXRPqDXC4rEVKbcdsy7W0FxoZb4WmEs7w==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-27.5.1.tgz",
+      "integrity": "sha512-QQOOdY4PE39iawDn5rzbIePNigfe5B9Z91GDD1ae/xNDlu9kaat8QQ5EKnNmVWPV54hUdxCVwwj6YMgR2O7IOg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.4.2",
-        "jest-regex-util": "^27.4.0",
-        "jest-snapshot": "^27.4.5"
+        "@jest/types": "^27.5.1",
+        "jest-regex-util": "^27.5.1",
+        "jest-snapshot": "^27.5.1"
       }
     },
     "jest-runner": {
-      "version": "27.4.5",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.4.5.tgz",
-      "integrity": "sha512-/irauncTfmY1WkTaRQGRWcyQLzK1g98GYG/8QvIPviHgO1Fqz1JYeEIsSfF+9mc/UTA6S+IIHFgKyvUrtiBIZg==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-27.5.1.tgz",
+      "integrity": "sha512-g4NPsM4mFCOwFKXO4p/H/kWGdJp9V8kURY2lX8Me2drgXqG7rrZAx5kv+5H7wtt/cdFIjhqYx1HrlqWHaOvDaQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.4.2",
-        "@jest/environment": "^27.4.4",
-        "@jest/test-result": "^27.4.2",
-        "@jest/transform": "^27.4.5",
-        "@jest/types": "^27.4.2",
+        "@jest/console": "^27.5.1",
+        "@jest/environment": "^27.5.1",
+        "@jest/test-result": "^27.5.1",
+        "@jest/transform": "^27.5.1",
+        "@jest/types": "^27.5.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.8.1",
-        "exit": "^0.1.2",
-        "graceful-fs": "^4.2.4",
-        "jest-docblock": "^27.4.0",
-        "jest-environment-jsdom": "^27.4.4",
-        "jest-environment-node": "^27.4.4",
-        "jest-haste-map": "^27.4.5",
-        "jest-leak-detector": "^27.4.2",
-        "jest-message-util": "^27.4.2",
-        "jest-resolve": "^27.4.5",
-        "jest-runtime": "^27.4.5",
-        "jest-util": "^27.4.2",
-        "jest-worker": "^27.4.5",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^27.5.1",
+        "jest-environment-jsdom": "^27.5.1",
+        "jest-environment-node": "^27.5.1",
+        "jest-haste-map": "^27.5.1",
+        "jest-leak-detector": "^27.5.1",
+        "jest-message-util": "^27.5.1",
+        "jest-resolve": "^27.5.1",
+        "jest-runtime": "^27.5.1",
+        "jest-util": "^27.5.1",
+        "jest-worker": "^27.5.1",
         "source-map-support": "^0.5.6",
         "throat": "^6.0.1"
       }
     },
     "jest-runtime": {
-      "version": "27.4.5",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.4.5.tgz",
-      "integrity": "sha512-CIYqwuJQXHQtPd/idgrx4zgJ6iCb6uBjQq1RSAGQrw2S8XifDmoM1Ot8NRd80ooAm+ZNdHVwsktIMGlA1F1FAQ==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-27.5.1.tgz",
+      "integrity": "sha512-o7gxw3Gf+H2IGt8fv0RiyE1+r83FJBRruoA+FXrlHw6xEyBsU8ugA6IPfTdVyA0w8HClpbK+DGJxH59UrNMx8A==",
       "dev": true,
       "requires": {
-        "@jest/console": "^27.4.2",
-        "@jest/environment": "^27.4.4",
-        "@jest/globals": "^27.4.4",
-        "@jest/source-map": "^27.4.0",
-        "@jest/test-result": "^27.4.2",
-        "@jest/transform": "^27.4.5",
-        "@jest/types": "^27.4.2",
-        "@types/yargs": "^16.0.0",
+        "@jest/environment": "^27.5.1",
+        "@jest/fake-timers": "^27.5.1",
+        "@jest/globals": "^27.5.1",
+        "@jest/source-map": "^27.5.1",
+        "@jest/test-result": "^27.5.1",
+        "@jest/transform": "^27.5.1",
+        "@jest/types": "^27.5.1",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
         "collect-v8-coverage": "^1.0.0",
         "execa": "^5.0.0",
-        "exit": "^0.1.2",
         "glob": "^7.1.3",
-        "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^27.4.5",
-        "jest-message-util": "^27.4.2",
-        "jest-mock": "^27.4.2",
-        "jest-regex-util": "^27.4.0",
-        "jest-resolve": "^27.4.5",
-        "jest-snapshot": "^27.4.5",
-        "jest-util": "^27.4.2",
-        "jest-validate": "^27.4.2",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^27.5.1",
+        "jest-message-util": "^27.5.1",
+        "jest-mock": "^27.5.1",
+        "jest-regex-util": "^27.5.1",
+        "jest-resolve": "^27.5.1",
+        "jest-snapshot": "^27.5.1",
+        "jest-util": "^27.5.1",
         "slash": "^3.0.0",
-        "strip-bom": "^4.0.0",
-        "yargs": "^16.2.0"
+        "strip-bom": "^4.0.0"
       }
     },
     "jest-serializer": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-27.4.0.tgz",
-      "integrity": "sha512-RDhpcn5f1JYTX2pvJAGDcnsNTnsV9bjYPU8xcV+xPwOXnUPOQwf4ZEuiU6G9H1UztH+OapMgu/ckEVwO87PwnQ==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-27.5.1.tgz",
+      "integrity": "sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==",
       "dev": true,
       "requires": {
         "@types/node": "*",
-        "graceful-fs": "^4.2.4"
+        "graceful-fs": "^4.2.9"
       }
     },
     "jest-snapshot": {
-      "version": "27.4.5",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.4.5.tgz",
-      "integrity": "sha512-eCi/iM1YJFrJWiT9de4+RpWWWBqsHiYxFG9V9o/n0WXs6GpW4lUt4FAHAgFPTLPqCUVzrMQmSmTZSgQzwqR7IQ==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-27.5.1.tgz",
+      "integrity": "sha512-yYykXI5a0I31xX67mgeLw1DZ0bJB+gpq5IpSuCAoyDi0+BhgU/RIrL+RTzDmkNTchvDFWKP8lp+w/42Z3us5sA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.7.2",
         "@babel/generator": "^7.7.2",
-        "@babel/parser": "^7.7.2",
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/traverse": "^7.7.2",
         "@babel/types": "^7.0.0",
-        "@jest/transform": "^27.4.5",
-        "@jest/types": "^27.4.2",
+        "@jest/transform": "^27.5.1",
+        "@jest/types": "^27.5.1",
         "@types/babel__traverse": "^7.0.4",
         "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^27.4.2",
-        "graceful-fs": "^4.2.4",
-        "jest-diff": "^27.4.2",
-        "jest-get-type": "^27.4.0",
-        "jest-haste-map": "^27.4.5",
-        "jest-matcher-utils": "^27.4.2",
-        "jest-message-util": "^27.4.2",
-        "jest-resolve": "^27.4.5",
-        "jest-util": "^27.4.2",
+        "expect": "^27.5.1",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^27.5.1",
+        "jest-get-type": "^27.5.1",
+        "jest-haste-map": "^27.5.1",
+        "jest-matcher-utils": "^27.5.1",
+        "jest-message-util": "^27.5.1",
+        "jest-util": "^27.5.1",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^27.4.2",
+        "pretty-format": "^27.5.1",
         "semver": "^7.3.2"
       }
     },
     "jest-util": {
-      "version": "27.4.2",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.4.2.tgz",
-      "integrity": "sha512-YuxxpXU6nlMan9qyLuxHaMMOzXAl5aGZWCSzben5DhLHemYQxCc4YK+4L3ZrCutT8GPQ+ui9k5D8rUJoDioMnA==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.5.1.tgz",
+      "integrity": "sha512-Kv2o/8jNvX1MQ0KGtw480E/w4fBCDOnH6+6DmeKi6LZUIlKA5kwY0YNdlzaWTiVgxqAqik11QyxDOKk543aKXw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.4.2",
+        "@jest/types": "^27.5.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.4",
+        "graceful-fs": "^4.2.9",
         "picomatch": "^2.2.3"
       }
     },
     "jest-validate": {
-      "version": "27.4.2",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.4.2.tgz",
-      "integrity": "sha512-hWYsSUej+Fs8ZhOm5vhWzwSLmVaPAxRy+Mr+z5MzeaHm9AxUpXdoVMEW4R86y5gOobVfBsMFLk4Rb+QkiEpx1A==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-27.5.1.tgz",
+      "integrity": "sha512-thkNli0LYTmOI1tDB3FI1S1RTp/Bqyd9pTarJwL87OIBFuqEb5Apv5EaApEudYg4g86e3CT6kM0RowkhtEnCBQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.4.2",
+        "@jest/types": "^27.5.1",
         "camelcase": "^6.2.0",
         "chalk": "^4.0.0",
-        "jest-get-type": "^27.4.0",
+        "jest-get-type": "^27.5.1",
         "leven": "^3.1.0",
-        "pretty-format": "^27.4.2"
+        "pretty-format": "^27.5.1"
       },
       "dependencies": {
         "camelcase": {
@@ -2822,24 +2826,24 @@
       }
     },
     "jest-watcher": {
-      "version": "27.4.2",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.4.2.tgz",
-      "integrity": "sha512-NJvMVyyBeXfDezhWzUOCOYZrUmkSCiatpjpm+nFUid74OZEHk6aMLrZAukIiFDwdbqp6mTM6Ui1w4oc+8EobQg==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-27.5.1.tgz",
+      "integrity": "sha512-z676SuD6Z8o8qbmEGhoEUFOM1+jfEiL3DXHK/xgEiG2EyNYfFG60jluWcupY6dATjfEsKQuibReS1djInQnoVw==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^27.4.2",
-        "@jest/types": "^27.4.2",
+        "@jest/test-result": "^27.5.1",
+        "@jest/types": "^27.5.1",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "jest-util": "^27.4.2",
+        "jest-util": "^27.5.1",
         "string-length": "^4.0.1"
       }
     },
     "jest-worker": {
-      "version": "27.4.5",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.4.5.tgz",
-      "integrity": "sha512-f2s8kEdy15cv9r7q4KkzGXvlY0JTcmCbMHZBfSQDwW77REr45IDWwd0lksDFeVHH2jJ5pqb90T77XscrjeGzzg==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -2914,6 +2918,12 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -2927,13 +2937,10 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "dev": true
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -2974,6 +2981,12 @@
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
       }
+    },
+    "lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
     },
     "locate-path": {
       "version": "5.0.0",
@@ -3056,28 +3069,28 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       }
     },
     "mime-db": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.34",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
-      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "requires": {
-        "mime-db": "1.51.0"
+        "mime-db": "1.52.0"
       }
     },
     "mimic-fn": {
@@ -3087,19 +3100,13 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
-    },
-    "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
     },
     "ms": {
       "version": "2.1.2",
@@ -3120,9 +3127,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
-      "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
+      "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
       "dev": true
     },
     "normalize-path": {
@@ -3211,6 +3218,18 @@
         "callsites": "^3.0.0"
       }
     },
+    "parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      }
+    },
     "parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -3294,9 +3313,9 @@
       "dev": true
     },
     "pirates": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.4.tgz",
-      "integrity": "sha512-ZIrVPH+A52Dw84R0L3/VS9Op04PuQ2SEoJL6bkshmiTic/HldyW9Tf7oH5mhJZBK7NmDx27vSMrYEXPXclpDKw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
+      "integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==",
       "dev": true
     },
     "pkg-dir": {
@@ -3315,12 +3334,11 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "27.4.2",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.2.tgz",
-      "integrity": "sha512-p0wNtJ9oLuvgOQDEIZ9zQjZffK7KtyR6Si0jnXULIDwrlNF8Cuir3AZP0hHv0jmKuNN/edOnbMjnzd4uTcmWiw==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.4.2",
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
         "react-is": "^17.0.1"
@@ -3381,12 +3399,12 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
-      "integrity": "sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
       "dev": true,
       "requires": {
-        "is-core-module": "^2.8.0",
+        "is-core-module": "^2.8.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
@@ -3521,9 +3539,9 @@
       "dev": true
     },
     "signal-exit": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
-      "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
     "sisteransi": {
@@ -3838,9 +3856,9 @@
       "dev": true
     },
     "v8-to-istanbul": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.1.0.tgz",
-      "integrity": "sha512-/PRhfd8aTNp9Ggr62HPzXg2XasNFGy5PBt0Rp04du7/8GNNSgxFL6WBTkgMKSL9bFjH+8kKEG3f37FmxiTqUUA==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.1.1.tgz",
+      "integrity": "sha512-FGtKtv3xIpR6BYhvgH8MI/y78oT7d8Au3ww4QIxymrCtZEh5b8gCw2siywE+puhEmuWKDtmfrvF5UlB298ut3w==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.1",
@@ -3960,9 +3978,9 @@
       }
     },
     "ws": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
-      "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
+      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
       "dev": true
     },
     "xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "ts-runtime-typecheck",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "A collection of common types for TypeScript along with dynamic type cast methods.",
   "main": "cjs/index.js",
   "module": "mjs/index.mjs",
   "types": "mjs/index.d.ts",
   "scripts": {
     "test": "jest --verbose --coverage",
-    "lint": "eslint",
+    "lint": "eslint src",
+    "typecheck": "tsc --noEmit --watch",
     "build": "rollup -c && cp ./package.json ./dist/package.json && cp ./README.md ./dist/README.md"
   },
   "repository": {

--- a/src/TypeCast.type.ts
+++ b/src/TypeCast.type.ts
@@ -1,4 +1,12 @@
 import type { Optional } from './Optional.type';
 
-export type TypeCast<Output, Input = unknown> = (value: Input, fallback?: Output) => Output;
+export interface TypeCast<Output, Input = unknown> {
+  (value: Input): Output;
+  /**
+   * @deprecated The argument parameter is depreciated.
+   * Please use `asType(value ?? fallback)` instead.
+   */
+  (value: Input, fallback?: Output): Output;
+}
+// export type TypeCast<Output, Input = unknown> = (value: Input, fallback?: Output) => Output;
 export type OptionalTypeCast<Output, Input = unknown> = (value: Optional<Input>) => Output | undefined;

--- a/src/invariant.ts
+++ b/src/invariant.ts
@@ -1,7 +1,7 @@
 import { TypeAssertion } from './TypeAssertion';
 
-export function invariant (condition: boolean, msg: string): asserts condition {
-  if (!condition) {
+export function invariant (isValid: boolean, msg: string): asserts isValid {
+  if (!isValid) {
     throw new TypeAssertion(msg);
   }
 }

--- a/src/type-cast/as-primitive.ts
+++ b/src/type-cast/as-primitive.ts
@@ -17,6 +17,12 @@ export const asFunction = typeCast(isFunction);
 // NOTE this *could* work with the typeCast helper
 // but unfortunately generic parameters cannot be preserved
 // when a function is placed into a value
+export function asDefined<T> (obj: Optional<T>): NonNullable<T>;
+/**
+ * @deprecated The fallback argument is depreciated.
+ * Please use `asDefined(value ?? fallback)` instead.
+ */
+export function asDefined<T> (obj: Optional<T>, fallback?: NonNullable<T>): NonNullable<T>;
 export function asDefined<T> (obj: Optional<T>, fallback?: NonNullable<T>): NonNullable<T> {
   if (isDefined(obj)) {
     return obj;

--- a/src/type-cast/as-union.test.ts
+++ b/src/type-cast/as-union.test.ts
@@ -15,7 +15,7 @@ describe('asUnion', () => {
     expect(() => cast(null)).toThrow('Unable to cast null to string | number');
   });
 });
-describe('isOptUnion', () => {
+describe('asOptUnion', () => {
   it('accepts a single param', () => {
     const cast = asOptUnion(isString);
 

--- a/src/type-cast/type-cast.test.ts
+++ b/src/type-cast/type-cast.test.ts
@@ -1,65 +1,65 @@
 import { optTypeCast, typeCast } from './type-cast';
 
 describe('typeCast', () => {
-  const passing_test_fn = (_obj: unknown): _obj is unknown => true;
-  passing_test_fn.TYPE_NAME = 'PassingTest';
-  const passing_cast_fn = typeCast(passing_test_fn);
-  const failing_test_fn = (_obj: unknown): _obj is unknown => false;
-  failing_test_fn.TYPE_NAME = 'FailingTest';
-  const failing_cast_fn = typeCast(failing_test_fn);
+  const passingTestFn = (obj: unknown): obj is unknown => obj === obj;
+  passingTestFn.TYPE_NAME = 'PassingTest';
+  const passingCastFn = typeCast(passingTestFn);
+  const failingTestFn = (obj: unknown): obj is unknown => obj !== obj;
+  failingTestFn.TYPE_NAME = 'FailingTest';
+  const failingCastFn = typeCast(failingTestFn);
 
   it('emits value with passing test', () => {
-    expect(passing_cast_fn(12)).toBe(12);
+    expect(passingCastFn(12)).toBe(12);
   });
 
   it('throws with failing test', () => {
-    expect(() => failing_cast_fn(12)).toThrow('Unable to cast number to FailingTest');
+    expect(() => failingCastFn(12)).toThrow('Unable to cast number to FailingTest');
   });
 
   it('throws for nullish value with no fallback', () => {
-    expect(() => failing_cast_fn(undefined)).toThrow('Unable to cast undefined to FailingTest');
+    expect(() => failingCastFn(undefined)).toThrow('Unable to cast undefined to FailingTest');
   });
 
   it('emits for nullish value with fallback', () => {
-    expect(failing_cast_fn(undefined, 12)).toBe(12);
+    expect(failingCastFn(undefined, 12)).toBe(12);
   });
 
-  const failing_test_no_label_fn = (_obj: unknown): _obj is unknown => false;
-  const failing_cast_no_label_fn = typeCast(failing_test_no_label_fn);
+  const failingTestNoLabelFn = (obj: unknown): obj is unknown => obj !== obj;
+  const failingCastNoLabelFn = typeCast(failingTestNoLabelFn);
 
   it('throws "unknown" with failing test and no label', () => {
-    expect(() => failing_cast_no_label_fn(12)).toThrow('Unable to cast number to unknown');
+    expect(() => failingCastNoLabelFn(12)).toThrow('Unable to cast number to unknown');
   });
 });
 
 describe('optTypeCast', () => {
-  const passing_test_fn = (_obj: unknown): _obj is unknown => true;
-  passing_test_fn.TYPE_NAME = 'PassingTest';
-  const passing_cast_fn = optTypeCast(passing_test_fn);
-  const failing_test_fn = (_obj: unknown): _obj is unknown => false;
-  failing_test_fn.TYPE_NAME = 'FailingTest';
-  const failing_cast_fn = optTypeCast(failing_test_fn);
+  const passingTestFn = (obj: unknown): obj is unknown => obj === obj;
+  passingTestFn.TYPE_NAME = 'PassingTest';
+  const passingCastFn = optTypeCast(passingTestFn);
+  const failingTestFn = (obj: unknown): obj is unknown => obj !== obj;
+  failingTestFn.TYPE_NAME = 'FailingTest';
+  const failingCastFn = optTypeCast(failingTestFn);
 
   it('emits value with passing test', () => {
-    expect(passing_cast_fn(12)).toBe(12);
+    expect(passingCastFn(12)).toBe(12);
   });
 
   it('throws with failing test', () => {
-    expect(() => failing_cast_fn(12)).toThrow('Unable to cast number to Optional<FailingTest>');
+    expect(() => failingCastFn(12)).toThrow('Unable to cast number to Optional<FailingTest>');
   });
 
   it('emits for nullish value with failing test', () => {
-    expect(failing_cast_fn(undefined)).toBe(undefined);
+    expect(failingCastFn(undefined)).toBe(undefined);
   });
 
   it('convert null to undefined', () => {
-    expect(failing_cast_fn(null)).toBe(undefined);
+    expect(failingCastFn(null)).toBe(undefined);
   });
 
-  const failing_test_no_label_fn = (_obj: unknown): _obj is unknown => false;
-  const failing_cast_no_label_fn = optTypeCast(failing_test_no_label_fn);
+  const failingTestNoLabelFn = (obj: unknown): obj is unknown => obj !== obj;
+  const failingCastNoLabelFn = optTypeCast(failingTestNoLabelFn);
 
   it('throws "unknown" with failing test and no label', () => {
-    expect(() => failing_cast_no_label_fn(12)).toThrow('Unable to cast number to Optional<unknown>');
+    expect(() => failingCastNoLabelFn(12)).toThrow('Unable to cast number to Optional<unknown>');
   });
 });

--- a/src/type-cast/type-cast.ts
+++ b/src/type-cast/type-cast.ts
@@ -1,6 +1,6 @@
 import type { Optional } from '../Optional.type';
 import type { TypeCheck } from '../TypeCheck.type';
-import type { OptionalTypeCast } from '../TypeCast.type';
+import type { OptionalTypeCast, TypeCast } from '../TypeCast.type';
 
 import { isNullish } from '../type-check/is-primitive';
 import { inspectType } from '../inspectType';
@@ -17,7 +17,7 @@ export function optTypeCast<Input, Output> (isType: TypeCheck<Output>): Optional
   };
 }
 
-export function typeCast<Output> (isType: TypeCheck<Output>): (obj: unknown, fallback?: Output) => Output {
+export function typeCast<Output> (isType: TypeCheck<Output>): TypeCast<Output> {
   return (obj: unknown, fallback?: Output) => {
     if (isType(obj)) {
       return obj;

--- a/src/type-check/is-instance.test.ts
+++ b/src/type-check/is-instance.test.ts
@@ -2,13 +2,13 @@ import { isInstance, isOptInstance } from './is-instance';
 
 describe('is instance', () => {
   class BaseClass {
-    inner = 0
+    inner = 0;
   }
   class ExtendedClass extends BaseClass {
-    outer = 'a word'
+    outer = 'a word';
   }
   class Similar {
-    inner = 1
+    inner = 1;
   }
 
   const base = new BaseClass;
@@ -37,13 +37,13 @@ describe('is instance', () => {
 
 describe('is optional instance', () => {
   class BaseClass {
-    inner = 0
+    inner = 0;
   }
   class ExtendedClass extends BaseClass {
-    outer = 'a word'
+    outer = 'a word';
   }
   class Similar {
-    inner = 1
+    inner = 1;
   }
 
   const base = new BaseClass;

--- a/src/type-check/is-recursive.test.ts
+++ b/src/type-check/is-recursive.test.ts
@@ -36,26 +36,26 @@ describe('is primitive', () => {
   function tryExamples<T>(test: TypeCheck<T>, expected: boolean[]) {
     for (let i = 0; i < examples.length; i++) {
       const example = examples[i];
-      const passes = expected[i];
+      const shouldPass = expected[i];
       let label = '';
       switch (typeof example) {
-      case 'symbol':
-        label = example.toString();
-        break;
-      case 'object':
-        if (example === null) {
-          label = 'null';
-        }
-        else {
+        case 'symbol':
+          label = example.toString();
+          break;
+        case 'object':
+          if (example === null) {
+            label = 'null';
+          }
+          else {
+            label = JSON.stringify(example);
+          }
+          break;
+        default:
           label = JSON.stringify(example);
-        }
-        break;
-      default:
-        label = example + '';
-        break;
+          break;
       }
-      it(`${label} is ${test.TYPE_NAME} === ${passes}`, () => {
-        expect(test(example)).toBe(passes);
+      it(`${label} is ${test.TYPE_NAME ?? 'unknown'} === ${shouldPass ? 'true' : 'false'}`, () => {
+        expect(test(example)).toBe(shouldPass);
       });
     }
   }
@@ -85,7 +85,7 @@ describe('is primitive', () => {
 
     it('uses correct labels', () => {
       expect(isDictionaryOf(isString).TYPE_NAME).toBe('Dictionary<string>');
-      expect(isDictionaryOf((_obj: unknown): _obj is unknown => true).TYPE_NAME).toBe('Dictionary<unknown>');
+      expect(isDictionaryOf((obj: unknown): obj is unknown => obj === obj).TYPE_NAME).toBe('Dictionary<unknown>');
     });
   });
 
@@ -114,7 +114,7 @@ describe('is primitive', () => {
 
     it('uses correct labels', () => {
       expect(isOptDictionaryOf(isString).TYPE_NAME).toBe('Optional<Dictionary<string>>');
-      expect(isOptDictionaryOf((_obj: unknown): _obj is unknown => true).TYPE_NAME).toBe('Optional<Dictionary<unknown>>');
+      expect(isOptDictionaryOf((obj: unknown): obj is unknown => obj === obj).TYPE_NAME).toBe('Optional<Dictionary<unknown>>');
     });
   });
 
@@ -143,7 +143,7 @@ describe('is primitive', () => {
 
     it('uses correct labels', () => {
       expect(isArrayOf(isString).TYPE_NAME).toBe('string[]');
-      expect(isArrayOf((_obj: unknown): _obj is unknown => true).TYPE_NAME).toBe('unknown[]');
+      expect(isArrayOf((obj: unknown): obj is unknown => obj === obj).TYPE_NAME).toBe('unknown[]');
     });
   });
 
@@ -172,7 +172,7 @@ describe('is primitive', () => {
 
     it('uses correct labels', () => {
       expect(isOptArrayOf(isString).TYPE_NAME).toBe('Optional<string[]>');
-      expect(isOptArrayOf((_obj: unknown): _obj is unknown => true).TYPE_NAME).toBe('Optional<unknown[]>');
+      expect(isOptArrayOf((obj: unknown): obj is unknown => obj === obj).TYPE_NAME).toBe('Optional<unknown[]>');
     });
   });
 });

--- a/src/type-check/is-struct.test.ts
+++ b/src/type-check/is-struct.test.ts
@@ -81,7 +81,7 @@ describe('is struct', () => {
   });
 
   it('does not add a type to the label if the TypeAssert does not hold one', () => {
-    const test: TypeCheck<string> = (_obj: unknown): _obj is string => true;
+    const test: TypeCheck<string> = (obj: unknown): obj is string => obj === obj;
     const { TYPE_NAME } = isStruct({ a: test }); 
     expect(TYPE_NAME).toBe('{ a }');
   });
@@ -167,7 +167,7 @@ describe('is optional struct', () => {
   });
 
   it('does not add a type to the label if the TypeAssert does not hold one', () => {
-    const test: TypeCheck<string> = (_obj: unknown): _obj is string => true;
+    const test: TypeCheck<string> = (obj: unknown): obj is string => obj === obj;
     const { TYPE_NAME } = isOptStruct({ a: test }); 
     expect(TYPE_NAME).toBe('{ a }');
   });

--- a/src/type-check/is-union.test.ts
+++ b/src/type-check/is-union.test.ts
@@ -13,7 +13,7 @@ describe('isUnion', () => {
     expect(isUnion(isString, isNumber, isNullish)(null)).toBeTruthy();
   });
   it('accepts test with no TYPE_NAME', () => {
-    expect(isUnion((_n: unknown): _n is number => true).TYPE_NAME).toBe('unknown');
+    expect(isUnion((n: unknown): n is number => n === n).TYPE_NAME).toBe('unknown');
   });
 });
 describe('isOptUnion', () => {
@@ -33,6 +33,6 @@ describe('isOptUnion', () => {
     expect(isOptUnion(isNullish)(undefined)).toBeTruthy();
   });
   it('accepts test with no TYPE_NAME', () => {
-    expect(isOptUnion((_n: unknown): _n is number => true).TYPE_NAME).toBe('Optional<unknown>');
+    expect(isOptUnion((n: unknown): n is number => n === n).TYPE_NAME).toBe('Optional<unknown>');
   });
 });


### PR DESCRIPTION
- depreciate fallback parameter for general type casts
- depreciate fallback parameter for asDefined
- introduce new naming convention style rule
- fix `lint` script
- add `typecheck` script
- bump maintenance version
- correct some linting errors
- rename misnamed test for asOptUnion
- update documentation

Closes #44 